### PR TITLE
Changed Errors to match mailgun api error types

### DIFF
--- a/lib/mailgun/mailgun_error.rb
+++ b/lib/mailgun/mailgun_error.rb
@@ -1,4 +1,54 @@
 module Mailgun
-  class Error < StandardError
+  class Error
+    attr_accessor :error
+
+    def initialize(options={})
+      @error =
+        case options[:code]
+        when 200
+          # Not an error
+        when 404
+          Mailgun::NotFound.new(options[:message])
+        when 400
+          Mailgun::BadRequest.new(options[:message])
+        when 401
+          Mailgun::Unauthorized.new(options[:message])
+        when 402
+          Mailgun::ResquestFailed.new(options[:message])
+        when 500, 502, 503, 504
+          Mailgun::ServerError.new(options[:message])
+        else
+          Mailgun::ErrorBase.new(options[:message])
+        end
+    end
+
+    def handle
+      return error.handle
+    end
+  end
+
+  class ErrorBase < StandardError
+    # Handles the error if needed
+    # by default returns an error
+    #
+    # @return [type] [description]
+    def handle
+      return self
+    end
+  end
+
+  class NotFound < ErrorBase
+    def handle
+      return nil
+    end
+  end
+
+  class BadRequest < ErrorBase
+  end
+
+  class Unauthorized < ErrorBase
+  end
+
+  class ResquestFailed < ErrorBase
   end
 end


### PR DESCRIPTION
Changed errors to return understandable Mailgun api errors in order to be able to catch specific errors and handle it in your app.

New error classes are:

```Ruby
Mailgun::NotFound
Mailgun::BadRequest
Mailgun::Unauthorized
Mailgun::ResquestFailed
Mailgun::ServerError
Mailgun::ErrorBase
```
