### PR TITLE
Add support for webhooks, and address validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.byebug_history

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,7 @@
 
 * Yomi Colledge / [@baphled](http://github.com/baphled)
   * For refactoring API configuration and some documentation
+
+* Gregory Hilkert / [@EpiphanyMachine](http://github.com/EpiphanyMachine) and [@asheeshchoksi](https://github.com/asheeshchoksi)
+  * Support for Webhooks API
+  * Support for Address API

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Mailgun exposes the following resources:
   * Unsubscribes
   * Complaints
   * Domain management
+  * Webhook management
+  * Address Validation
 
 Patches are welcome (and easy!).
 
@@ -179,6 +181,36 @@ Supported route actions are: `:forward`, and `:stop`
 
 # Remove a domain
 @mailbox.domains.delete "example.com"
+```
+
+#### Webhooks
+```ruby
+# List of currently available webhooks
+@mailgun.webhooks.available_ids
+
+# Returns a list of webhooks set for the specified domain
+@mailgun.webhooks.list
+
+# Returns details about the webhook specified
+@mailgun.webhooks.find(:open)
+
+# Creates a new webhook
+# Note: Creating an Open or Click webhook will enable Open or Click tracking
+@mailgun.webhooks.create(:open, "http://bin.example.com/8de4a9c4")
+
+# Updates an existing webhook
+@mailgun.webhooks.update(:open, "http://bin.example.com/8de4a9c4")
+
+# Deletes an existing webhook
+# Note: Deleting an Open or Click webhook will disable Open or Click tracking
+@mailgun.webhooks.delete(:open)
+```
+
+#### Address Validation
+Requires the `public_api_key` to be set.  The Mailgun public key is available in the My Account tab of the Control Panel.
+```ruby
+# Given an arbitrary address, validates address based off defined checks
+@mailgun.addresses.validate('hello@example.com')
 ```
 
 ## Making Your Changes

--- a/lib/mailgun.rb
+++ b/lib/mailgun.rb
@@ -11,17 +11,21 @@ require "mailgun/route"
 require "mailgun/mailbox"
 require "mailgun/bounce"
 require "mailgun/unsubscribe"
+require "mailgun/webhook"
 require "mailgun/complaint"
 require "mailgun/log"
 require "mailgun/list"
 require "mailgun/list/member"
 require "mailgun/message"
 require "mailgun/secure"
+require "mailgun/address"
 
 #require "startup"
 
 def Mailgun(options={})
   options[:api_key] = Mailgun.api_key if Mailgun.api_key
   options[:domain] = Mailgun.domain if Mailgun.domain
+  options[:webhook_url] = Mailgun.webhook_url if Mailgun.webhook_url
+  options[:public_api_key] = Mailgun.public_api_key if Mailgun.public_api_key
   Mailgun::Base.new(options)
 end

--- a/lib/mailgun/address.rb
+++ b/lib/mailgun/address.rb
@@ -1,0 +1,20 @@
+module Mailgun
+  # https://documentation.mailgun.com/api-email-validation.html#email-validation
+  class Address
+    # Used internally, called from Mailgun::Base
+    def initialize(mailgun)
+      @mailgun = mailgun
+    end
+
+    # Given an arbitrary address, validates address based off defined checks
+    def validate(email)
+      Mailgun.submit :get, address_url('validate'), {:address => email}
+    end
+
+    private
+
+    def address_url(action)
+      "#{@mailgun.public_base_url}/address/#{action}"
+    end
+  end
+end

--- a/lib/mailgun/webhook.rb
+++ b/lib/mailgun/webhook.rb
@@ -1,0 +1,55 @@
+module Mailgun
+  # Interface to manage webhooks
+  # https://documentation.mailgun.com/api-webhooks.html#webhooks
+  class Webhook
+    attr_accessor :default_webhook_url, :domain
+
+    # Used internally, called from Mailgun::Base
+    def initialize(mailgun, domain, url)
+      @mailgun = mailgun
+      @domain = domain
+      @default_webhook_url = url
+    end
+
+    # List of currently available webhooks
+    def available_ids
+      %w(bounce deliver drop spam unsubscribe click open).map(&:to_sym)
+    end
+
+    # Returns a list of webhooks set for the specified domain
+    def list
+      Mailgun.submit(:get, webhook_url)["webhooks"] || []
+    end
+
+    # Returns details about the webhook specified
+    def find(id)
+      Mailgun.submit :get, webhook_url(id)
+    end
+
+    # Creates a new webhook
+    # Note: Creating an Open or Click webhook will enable Open or Click tracking
+    def create(id, url=default_webhook_url)
+      params = {:id => id, :url => url}
+      Mailgun.submit :post, webhook_url, params
+    end
+
+    # Updates an existing webhook
+    def update(id, url=default_webhook_url)
+      params = {:url => url}
+      Mailgun.submit :put, webhook_url(id), params
+    end
+
+    # Deletes an existing webhook
+    # Note: Deleting an Open or Click webhook will disable Open or Click tracking
+    def delete(id)
+      Mailgun.submit :delete, webhook_url(id)
+    end
+
+    private
+
+    # Helper method to generate the proper url for Mailgun webhook API calls
+    def webhook_url(id=nil)
+      "#{@mailgun.base_url}/domains/#{domain}/webhooks#{'/' + id if id}"
+    end
+  end
+end

--- a/mailgun.gemspec
+++ b/mailgun.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |gem|
   gem.name          = "mailgun"
   gem.require_paths = ["lib"]
   gem.version       = "0.8"
-  
-  gem.add_dependency(%q<rest-client>, [">= 0"])  
+
+  gem.add_dependency(%q<rest-client>, [">= 0"])
 
   gem.add_development_dependency(%q<rspec>, [">= 2"])
-  gem.add_development_dependency(%q<debugger>, [">= 0"])
+  gem.add_development_dependency(%q<byebug>, [">= 0"])
   gem.add_development_dependency(%q<vcr>, [">= 0"])
 end

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Mailgun::Address do
+
+  before :each do
+    @sample = "foo@mailgun.net"
+  end
+
+  describe "validate an address" do
+    it "should require a public api key" do
+      mailgun = Mailgun({:api_key => "api-key"})
+      expect { mailgun.addresses }.to raise_error(ArgumentError, ":public_api_key is a required argument to validate addresses")
+    end
+    it "should make a GET request with correct params to find a given webhook" do
+      mailgun = Mailgun({:api_key => "api-key", :public_api_key => "public-api-key"})
+
+      sample_response = "{\"is_valid\":true,\"address\":\"foo@mailgun.net\",\"parts\":{\"display_name\":null,\"local_part\":\"foo\",\"domain\":\"mailgun.net\"},\"did_you_mean\":null}"
+      validate_url = mailgun.addresses.send(:address_url, 'validate')
+
+      Mailgun.should_receive(:submit).
+        with(:get, validate_url, {:address => @sample}).
+        and_return(sample_response)
+
+      mailgun.addresses.validate(@sample)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'simplecov'
 SimpleCov.start
 
 require "rspec"
+require "byebug"
 require "mailgun"
 
 RSpec.configure do |config|

--- a/spec/webhook_spec.rb
+++ b/spec/webhook_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+describe Mailgun::Webhook do
+
+  before :each do
+    @mailgun = Mailgun({:api_key => "api-key", :webhook_url => "http://postbin.heroku.com/860bcd65"})
+
+    @sample = {
+      :id     => "click",
+      :url    => "http://postbin.heroku.com/860bcd65"
+    }
+  end
+
+  describe "list avabilable webhook ids" do
+    it "should return the correct ids" do
+      @mailgun.webhooks.available_ids.should =~ %w(bounce deliver drop spam unsubscribe click open).map(&:to_sym)
+    end
+  end
+
+  describe "list webhooks" do
+    it "should make a GET request with the correct params" do
+
+      sample_response = "{\"total_count\": 1, \"items\": [{\"webhooks\":{\"open\":{\"url\":\"http://postbin.heroku.com/860bcd65\"},\"click\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}}]}"
+      webhooks_url = @mailgun.webhooks.send(:webhook_url)
+
+      Mailgun.should_receive(:submit).
+        with(:get, webhooks_url).
+        and_return(sample_response)
+
+      @mailgun.webhooks.list
+    end
+  end
+
+  describe "find a webhook" do
+    it "should make a GET request with correct params to find a given webhook" do
+      sample_response = "{\"webhook\": {\"url\":\"http://postbin.heroku.com/860bcd65\"}"
+      webhooks_url = @mailgun.webhooks.send(:webhook_url, @sample[:id])
+
+      Mailgun.should_receive(:submit).
+        with(:get, webhooks_url).
+        and_return(sample_response)
+
+      @mailgun.webhooks.find(@sample[:id])
+    end
+  end
+
+  describe "add a webhook" do
+    context "using the default webhook url" do
+      it "should make a POST request with correct params to add a webhook" do
+        sample_response = "{\"message\":\"Webhook has been created\",\"webhook\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}"
+        webhooks_url = @mailgun.webhooks.send(:webhook_url)
+
+        Mailgun.should_receive(:submit).
+          with(:post, webhooks_url, {:id => @sample[:id], :url => @sample[:url]}).
+          and_return(sample_response)
+
+        @mailgun.webhooks.create(@sample[:id])
+      end
+    end
+    context "overwriting the default webhook url" do
+      it "should make a POST request with correct params to add a webhook" do
+        sample_response = "{\"message\":\"Webhook has been created\",\"webhook\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}"
+        webhooks_url = @mailgun.webhooks.send(:webhook_url)
+        overwritten_url = 'http://mailgun.net/webhook'
+
+        Mailgun.should_receive(:submit).
+          with(:post, webhooks_url, {:id => @sample[:id], :url => overwritten_url}).
+          and_return(sample_response)
+
+        @mailgun.webhooks.create(@sample[:id], overwritten_url)
+      end
+    end
+  end
+
+  describe "update a webhook" do
+    context "using the default webhook url" do
+      it "should make a POST request with correct params to add a webhook" do
+        sample_response = "{\"message\":\"Webhook has been updated\",\"webhook\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}"
+        webhooks_url = @mailgun.webhooks.send(:webhook_url, @sample[:id])
+
+        Mailgun.should_receive(:submit).
+          with(:put, webhooks_url, {:url => @sample[:url]}).
+          and_return(sample_response)
+
+        @mailgun.webhooks.update(@sample[:id])
+      end
+    end
+    context "overwriting the default webhook url" do
+      it "should make a POST request with correct params to add a webhook" do
+        sample_response = "{\"message\":\"Webhook has been updated\",\"webhook\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}"
+        webhooks_url = @mailgun.webhooks.send(:webhook_url, @sample[:id])
+        overwritten_url = 'http://mailgun.net/webhook'
+
+        Mailgun.should_receive(:submit).
+          with(:put, webhooks_url, {:url => overwritten_url}).
+          and_return(sample_response)
+
+        @mailgun.webhooks.update(@sample[:id], overwritten_url)
+      end
+    end
+  end
+
+  describe "delete a webhook" do
+    it "should make a DELETE request with correct params" do
+      sample_response = "{\"message\":\"Webhook has been deleted\",\"webhook\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}"
+      webhooks_url = @mailgun.webhooks.send(:webhook_url, @sample[:id])
+
+      Mailgun.should_receive(:submit).
+        with(:delete, webhooks_url).
+        and_return(sample_response)
+
+      @mailgun.webhooks.delete(@sample[:id])
+    end
+  end
+end


### PR DESCRIPTION
- closes #46 
- replaced debugger with byebug for use with ruby 2
- added support for webhook endpoints
- added support for address validate endpoint
  - this required adding the public key
  - the public key is required to call the address.validate method, but is not required otherwise