### PR TITLE
Remove RestClient dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 2.2
+
+script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
 
-script: bundle exec rspec
+cache: bundler
+
+script: bundle exec rspec --color

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 2.2
   - 2.3.0
 
+before_install:
+  - gem install bundler
+
 cache: bundler
 
 script: bundle exec rspec --color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 rvm:
+  - 2.0
+  - 2.1
   - 2.2
+  - 2.3
 
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org'
 
 group :development do
   gem "simplecov", :require => false, :group => :test
-  gem 'pry'
 end
 
 # Specify your gem's dependencies in mailgun.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'http://rubygems.org'
 
 group :development do
   gem "simplecov", :require => false, :group => :test
+  gem 'pry'
 end
 
 # Specify your gem's dependencies in mailgun.gemspec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mailgun rubygem
 
+![](https://travis-ci.org/HashNuke/mailgun.svg?branch=master)
+
 This gem allows for idiomatic Mailgun usage from within ruby. Mailgun is a kickass email-as-a-service that lets you use email as if it made sense. Check it out at http://mailgun.net
 
 Mailgun exposes the following resources:

--- a/lib/mailgun.rb
+++ b/lib/mailgun.rb
@@ -19,6 +19,7 @@ require "mailgun/list/member"
 require "mailgun/message"
 require "mailgun/secure"
 require "mailgun/address"
+require "mailgun/client"
 
 #require "startup"
 

--- a/lib/mailgun.rb
+++ b/lib/mailgun.rb
@@ -1,4 +1,3 @@
-require "rest-client"
 require "json"
 require "multimap/lib/multimap"
 require "multimap/lib/multiset"

--- a/lib/mailgun/base.rb
+++ b/lib/mailgun/base.rb
@@ -90,23 +90,18 @@ module Mailgun
   # Submits the API call to the Mailgun server
   def self.submit(method, url, parameters={})
     begin
-      parameters = {:params => parameters} if method == :get
-      return JSON.parse(Client.new(url).send(method, parameters))
+      JSON.parse(Client.new(url).send(method, parameters))
     rescue => e
-      begin
-        error_code = e.http_code
-        error_message = JSON(e.http_body)["message"]
-        error = Mailgun::Error.new(
-          :code => error_code || nil,
-          :message => error_message || nil
-        )
-        if error.handle.kind_of? Mailgun::ErrorBase
-          raise error
-        else
-          return error.handle
-        end
-      rescue
-        raise e
+      error_code = e.http_code
+      error_message = JSON(e.http_body)["message"]
+      error = Mailgun::Error.new(
+        :code => error_code || nil,
+        :message => error_message || nil
+      )
+      if error.handle.kind_of? Mailgun::ErrorBase
+        raise error.handle
+      else
+        raise error
       end
     end
   end

--- a/lib/mailgun/base.rb
+++ b/lib/mailgun/base.rb
@@ -91,7 +91,7 @@ module Mailgun
   def self.submit(method, url, parameters={})
     begin
       parameters = {:params => parameters} if method == :get
-      return JSON.parse(RestClient.send(method, url, parameters))
+      return JSON.parse(Client.new(url).send(method, parameters))
     rescue => e
       begin
         error_code = e.http_code

--- a/lib/mailgun/base.rb
+++ b/lib/mailgun/base.rb
@@ -93,7 +93,11 @@ module Mailgun
       JSON.parse(Client.new(url).send(method, parameters))
     rescue => e
       error_code = e.http_code
-      error_message = JSON(e.http_body)["message"]
+      error_message = begin
+        JSON(e.http_body)["message"]
+      rescue JSON::ParserError
+        ''
+      end
       error = Mailgun::Error.new(
         :code => error_code || nil,
         :message => error_message || nil

--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -81,7 +81,6 @@ module Mailgun
   end
 end
 
-
 module Mailgun
   class ClientError < StandardError
     attr_accessor :http_code, :http_body

--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -40,7 +40,20 @@ module Mailgun
 
     def make_request(request)
       set_auth(request)
-      http_client.request(request)
+      response = http_client.request(request)
+
+      check_for_errors(response)
+
+      response.body
+    end
+
+    def check_for_errors(response)
+      return if response.code == '200'
+
+      error = ClientError.new
+      error.http_code = response.code.to_i
+      error.http_body = response.body
+      raise error
     end
 
     def path
@@ -65,5 +78,12 @@ module Mailgun
     def set_auth(request)
       request.basic_auth(parsed_url.user, parsed_url.password)
     end
+  end
+end
+
+
+module Mailgun
+  class ClientError < StandardError
+    attr_accessor :http_code, :http_body
   end
 end

--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -1,0 +1,69 @@
+module Mailgun
+  class Client
+    attr_reader :url
+
+    def initialize(url)
+      @url = url
+    end
+
+    def get(params = {})
+      request_path = path
+      request_path += "?#{URI.encode_www_form(params)}" if params.any?
+
+      request = Net::HTTP::Get.new(request_path)
+
+      make_request(request)
+    end
+
+    def post(params = {})
+      request = Net::HTTP::Post.new(path)
+      request.set_form_data(params)
+
+      make_request(request)
+    end
+
+    def put(params = {})
+      request = Net::HTTP::Put.new(path)
+      request.set_form_data(params)
+
+      make_request(request)
+    end
+
+    def delete(params = {})
+      request = Net::HTTP::Delete.new(path)
+      request.set_form_data(params)
+
+      make_request(request)
+    end
+
+    private
+
+    def make_request(request)
+      set_auth(request)
+      http_client.request(request)
+    end
+
+    def path
+      parsed_url.path
+    end
+
+    def parsed_url
+      @parsed_url ||= URI.parse url
+    end
+
+    def http_client
+      http = Net::HTTP.new(mailgun_url.host, mailgun_url.port)
+      http.use_ssl = true
+      http.set_debug_output STDOUT
+      http
+    end
+
+    def mailgun_url
+      URI.parse Mailgun().base_url
+    end
+
+    def set_auth(request)
+      request.basic_auth(parsed_url.user, parsed_url.password)
+    end
+  end
+end

--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -67,7 +67,6 @@ module Mailgun
     def http_client
       http = Net::HTTP.new(mailgun_url.host, mailgun_url.port)
       http.use_ssl = true
-      http.set_debug_output STDOUT
       http
     end
 

--- a/lib/mailgun/mailgun_error.rb
+++ b/lib/mailgun/mailgun_error.rb
@@ -51,4 +51,7 @@ module Mailgun
 
   class ResquestFailed < ErrorBase
   end
+
+  class ServerError < ErrorBase
+  end
 end

--- a/lib/mailgun/route.rb
+++ b/lib/mailgun/route.rb
@@ -4,7 +4,7 @@ module Mailgun
     def initialize(mailgun)
       @mailgun = mailgun
     end
-    
+
     def list(options={})
       Mailgun.submit(:get, route_url, options)["items"] || []
     end
@@ -34,8 +34,8 @@ module Mailgun
 
     def update(route_id, params)
       data = ::Multimap.new
-      
-      params.stringify_keys!
+
+      params = params.map{|k,v| [k.to_s, v]}.to_h
 
       ['priority', 'description'].each do |key|
         data[key] = params[key] if params.has_key?(key)
@@ -50,16 +50,16 @@ module Mailgun
           data['action'] = action
         end
       end
-      
+
       data = data.to_hash
 
       Mailgun.submit(:put, route_url(route_id), data)
     end
-    
+
     def destroy(route_id)
       Mailgun.submit(:delete, route_url(route_id))["id"]
     end
-    
+
     private
 
     def route_url(route_id=nil)

--- a/lib/mailgun/route.rb
+++ b/lib/mailgun/route.rb
@@ -1,6 +1,5 @@
 module Mailgun
   class Route
-
     def initialize(mailgun)
       @mailgun = mailgun
     end

--- a/lib/mailgun/route.rb
+++ b/lib/mailgun/route.rb
@@ -34,7 +34,7 @@ module Mailgun
     def update(route_id, params)
       data = ::Multimap.new
 
-      params = params.map{|k,v| [k.to_s, v]}.to_h
+      params = Hash[params.map{ |k, v| [k.to_s, v] }]
 
       ['priority', 'description'].each do |key|
         data[key] = params[key] if params.has_key?(key)

--- a/lib/multimap/spec/enumerable_examples.rb
+++ b/lib/multimap/spec/enumerable_examples.rb
@@ -1,50 +1,50 @@
 shared_examples_for Enumerable, Multimap, "with inital values {'a' => [100], 'b' => [200, 300]}" do
   it "should check all key/value pairs for condition" do
-    @map.all? { |key, value| key =~ /\w/ }.should be_true
-    @map.all? { |key, value| key =~ /\d/ }.should be_false
-    @map.all? { |key, value| value > 0 }.should be_true
-    @map.all? { |key, value| value > 200 }.should be_false
+    expect(@map.all? { |key, value| key =~ /\w/ }).to be_true
+    expect(@map.all? { |key, value| key =~ /\d/ }).to be_false
+    expect(@map.all? { |key, value| value > 0 }).to be_true
+    expect(@map.all? { |key, value| value > 200 }).to be_false
   end
 
   it "should check any key/value pairs for condition" do
-    @map.any? { |key, value| key == "a" }.should be_true
-    @map.any? { |key, value| key == "z" }.should be_false
-    @map.any? { |key, value| value == 100 }.should be_true
-    @map.any? { |key, value| value > 1000 }.should be_false
+    expect(@map.any? { |key, value| key == "a" }).to be_true
+    expect(@map.any? { |key, value| key == "z" }).to be_false
+    expect(@map.any? { |key, value| value == 100 }).to be_true
+    expect(@map.any? { |key, value| value > 1000 }).to be_false
   end
 
   it "should collect key/value pairs" do
-    @map.collect { |key, value| [key, value] }.should sorted_eql([["a", 100], ["b", 200], ["b", 300]])
-    @map.map { |key, value| [key, value] }.should sorted_eql([["a", 100], ["b", 200], ["b", 300]])
+    expect(@map.collect { |key, value| [key, value] }).to sorted_eql([["a", 100], ["b", 200], ["b", 300]])
+    expect(@map.map { |key, value| [key, value] }).to sorted_eql([["a", 100], ["b", 200], ["b", 300]])
   end
 
   it "should detect key/value pair" do
-    @map.detect { |key, value| value > 200 }.should eql(["b", 300])
-    @map.find { |key, value| value > 200 }.should eql(["b", 300])
+    expect(@map.detect { |key, value| value > 200 }).to eql(["b", 300])
+    expect(@map.find { |key, value| value > 200 }).to eql(["b", 300])
   end
 
   it "should return entries" do
-    @map.entries.should sorted_eql([["a", 100], ["b", 200], ["b", 300]])
-    @map.to_a.should sorted_eql([["a", 100], ["b", 200], ["b", 300]])
+    expect(@map.entries).to sorted_eql([["a", 100], ["b", 200], ["b", 300]])
+    expect(@map.to_a).to sorted_eql([["a", 100], ["b", 200], ["b", 300]])
   end
 
   it "should find all key/value pairs" do
-    @map.find_all { |key, value| value >= 200 }.should eql([["b", 200], ["b", 300]])
-    @map.select { |key, value| value >= 200 }.should eql(Multimap["b", [200, 300]])
+    expect(@map.find_all { |key, value| value >= 200 }).to eql([["b", 200], ["b", 300]])
+    expect(@map.select { |key, value| value >= 200 }).to eql(Multimap["b", [200, 300]])
   end
 
   it "should combine key/value pairs with inject" do
-    @map.inject(0) { |sum, (key, value)| sum + value }.should eql(600)
+    expect(@map.inject(0) { |sum, (key, value)| sum + value }).to eql(600)
 
     @map.inject(0) { |memo, (key, value)|
       memo > value ? memo : value
-    }.should eql(300)
+    expect(}).to eql(300)
   end
 
   it "should check for key membership" do
-    @map.member?("a").should be_true
-    @map.include?("a").should be_true
-    @map.member?("z").should be_false
-    @map.include?("z").should be_false
+    expect(@map.member?("a")).to be_true
+    expect(@map.include?("a")).to be_true
+    expect(@map.member?("z")).to be_false
+    expect(@map.include?("z")).to be_false
   end
 end

--- a/lib/multimap/spec/hash_examples.rb
+++ b/lib/multimap/spec/hash_examples.rb
@@ -8,152 +8,152 @@ shared_examples_for Hash, Multimap, "with inital values {'a' => [100], 'b' => [2
     map2["a"] = 100
     map2["b"] = 200
     map2["b"] = 300
-    @map.should eql(map2)
+    expect(@map).to eql(map2)
   end
 
   it "should not be equal to another Multimap if they contain different values" do
-    @map.should_not == Multimap["a" => [100], "b" => [200]]
+    expect(@map).to_not == Multimap["a" => [100], "b" => [200]]
   end
 
   it "should retrieve container of values for key" do
-    @map["a"].should eql(@container.new([100]))
-    @map["b"].should eql(@container.new([200, 300]))
-    @map["z"].should eql(@container.new)
+    expect(@map["a"]).to eql(@container.new([100]))
+    expect(@map["b"]).to eql(@container.new([200, 300]))
+    expect(@map["z"]).to eql(@container.new)
   end
 
   it "should append values to container at key" do
     @map["a"] = 400
     @map.store("b", 500)
-    @map["a"].should eql(@container.new([100, 400]))
-    @map["b"].should eql(@container.new([200, 300, 500]))
+    expect(@map["a"]).to eql(@container.new([100, 400]))
+    expect(@map["b"]).to eql(@container.new([200, 300, 500]))
   end
 
   it "should clear all key/values" do
     @map.clear
-    @map.should be_empty
+    expect(@map).to be_empty
   end
 
   it "should be the class of the container" do
-    @map.default.class.should eql(@container)
+    expect(@map.default.class).to eql(@container)
   end
 
   it "should delete all values at key" do
     @map.delete("a")
-    @map["a"].should eql(@container.new)
+    expect(@map["a"]).to eql(@container.new)
   end
 
   it "should delete single value at key" do
     @map.delete("b", 200)
-    @map["b"].should eql(@container.new([300]))
+    expect(@map["b"]).to eql(@container.new([300]))
   end
 
   it "should delete if key condition is matched" do
-    @map.delete_if { |key, value| key >= "b" }.should eql(@map)
-    @map["a"].should eql(@container.new([100]))
-    @map["b"].should eql(@container.new)
+    expect(@map.delete_if { |key, value| key >= "b" }).to eql(@map)
+    expect(@map["a"]).to eql(@container.new([100]))
+    expect(@map["b"]).to eql(@container.new)
 
-    @map.delete_if { |key, value| key > "z" }.should eql(@map)
+    expect(@map.delete_if { |key, value| key > "z" }).to eql(@map)
   end
 
   it "should delete if value condition is matched" do
-    @map.delete_if { |key, value| value >= 300 }.should eql(@map)
-    @map["a"].should eql(@container.new([100]))
-    @map["b"].should eql(@container.new([200]))
+    expect(@map.delete_if { |key, value| value >= 300 }).to eql(@map)
+    expect(@map["a"]).to eql(@container.new([100]))
+    expect(@map["b"]).to eql(@container.new([200]))
   end
 
   it "should duplicate the containers" do
     map2 = @map.dup
-    map2.should_not equal(@map)
-    map2.should eql(@map)
-    map2["a"].should_not equal(@map["a"])
-    map2["b"].should_not equal(@map["b"])
-    map2.default.should_not equal(@map.default)
-    map2.default.should eql(@map.default)
+    expect(map2).to_not equal(@map)
+    expect(map2).to eql(@map)
+    expect(map2["a"]).to_not equal(@map["a"])
+    expect(map2["b"]).to_not equal(@map["b"])
+    expect(map2.default).to_not equal(@map.default)
+    expect(map2.default).to eql(@map.default)
   end
 
   it "should freeze containers" do
     @map.freeze
-    @map.should be_frozen
-    @map["a"].should be_frozen
-    @map["b"].should be_frozen
+    expect(@map).to be_frozen
+    expect(@map["a"]).to be_frozen
+    expect(@map["b"]).to be_frozen
   end
 
   it "should iterate over each key/value pair and yield an array" do
     a = []
     @map.each { |pair| a << pair }
-    a.should sorted_eql([["a", 100], ["b", 200], ["b", 300]])
+    expect(a).to sorted_eql([["a", 100], ["b", 200], ["b", 300]])
   end
 
   it "should iterate over each container" do
     a = []
     @map.each_container { |container| a << container }
-    a.should sorted_eql([@container.new([100]), @container.new([200, 300])])
+    expect(a).to sorted_eql([@container.new([100]), @container.new([200, 300])])
   end
 
   it "should iterate over each key/container" do
     a = []
     @map.each_association { |key, container| a << [key, container] }
-    a.should sorted_eql([["a", @container.new([100])], ["b", @container.new([200, 300])]])
+    expect(a).to sorted_eql([["a", @container.new([100])], ["b", @container.new([200, 300])]])
   end
 
   it "should iterate over each key" do
     a = []
     @map.each_key { |key| a << key }
-    a.should sorted_eql(["a", "b", "b"])
+    expect(a).to sorted_eql(["a", "b", "b"])
   end
 
   it "should iterate over each key/value pair and yield the pair" do
     h = {}
     @map.each_pair { |key, value| (h[key] ||= []) << value }
-    h.should eql({ "a" => [100], "b" => [200, 300] })
+    expect(h).to eql({ "a" => [100], "b" => [200, 300] })
   end
 
   it "should iterate over each value" do
     a = []
     @map.each_value { |value| a << value }
-    a.should sorted_eql([100, 200, 300])
+    expect(a).to sorted_eql([100, 200, 300])
   end
 
   it "should be empty if there are no key/value pairs" do
     @map.clear
-    @map.should be_empty
+    expect(@map).to be_empty
   end
 
   it "should not be empty if there are any key/value pairs" do
-    @map.should_not be_empty
+    expect(@map).to_not be_empty
   end
 
   it "should fetch container of values for key" do
-    @map.fetch("a").should eql(@container.new([100]))
-    @map.fetch("b").should eql(@container.new([200, 300]))
-    lambda { @map.fetch("z") }.should raise_error(IndexError)
+    expect(@map.fetch("a")).to eql(@container.new([100]))
+    expect(@map.fetch("b")).to eql(@container.new([200, 300]))
+    expect(lambda { @map.fetch("z") }).to raise_error(IndexError)
   end
 
   it "should check if key is present" do
-    @map.has_key?("a").should be_true
-    @map.key?("a").should be_true
-    @map.has_key?("z").should be_false
-    @map.key?("z").should be_false
+    expect(@map.has_key?("a")).to be_true
+    expect(@map.key?("a")).to be_true
+    expect(@map.has_key?("z")).to be_false
+    expect(@map.key?("z")).to be_false
   end
 
   it "should check containers when looking up by value" do
-    @map.has_value?(100).should be_true
-    @map.value?(100).should be_true
-    @map.has_value?(999).should be_false
-    @map.value?(999).should be_false
+    expect(@map.has_value?(100)).to be_true
+    expect(@map.value?(100)).to be_true
+    expect(@map.has_value?(999)).to be_false
+    expect(@map.value?(999)).to be_false
   end
 
   it "it should return the index for value" do
     if @map.respond_to?(:index)
-      @map.index(200).should eql(@container.new(["b"]))
-      @map.index(999).should eql(@container.new)
+      expect(@map.index(200)).to eql(@container.new(["b"]))
+      expect(@map.index(999)).to eql(@container.new)
     end
   end
 
   it "should replace the contents of hash" do
     @map.replace({ "c" => @container.new([300]), "d" => @container.new([400]) })
-    @map["a"].should eql(@container.new)
-    @map["c"].should eql(@container.new([300]))
+    expect(@map["a"]).to eql(@container.new)
+    expect(@map["c"]).to eql(@container.new([300]))
   end
 
   it "should return an inverted Multimap" do
@@ -162,103 +162,103 @@ shared_examples_for Hash, Multimap, "with inital values {'a' => [100], 'b' => [2
       map2[100] = "a"
       map2[200] = "b"
       map2[300] = "b"
-      @map.invert.should eql(map2)
+      expect(@map.invert).to eql(map2)
     end
   end
 
   it "should return array of keys" do
-    @map.keys.should eql(["a", "b", "b"])
+    expect(@map.keys).to eql(["a", "b", "b"])
   end
 
   it "should return the number of key/value pairs" do
-    @map.length.should eql(3)
-    @map.size.should eql(3)
+    expect(@map.length).to eql(3)
+    expect(@map.size).to eql(3)
   end
 
   it "should duplicate map and with merged values" do
     map = @map.merge("b" => 254, "c" => @container.new([300]))
-    map["a"].should eql(@container.new([100]))
-    map["b"].should eql(@container.new([200, 300, 254]))
-    map["c"].should eql(@container.new([300]))
+    expect(map["a"]).to eql(@container.new([100]))
+    expect(map["b"]).to eql(@container.new([200, 300, 254]))
+    expect(map["c"]).to eql(@container.new([300]))
 
-    @map["a"].should eql(@container.new([100]))
-    @map["b"].should eql(@container.new([200, 300]))
-    @map["c"].should eql(@container.new)
+    expect(@map["a"]).to eql(@container.new([100]))
+    expect(@map["b"]).to eql(@container.new([200, 300]))
+    expect(@map["c"]).to eql(@container.new)
   end
 
   it "should update map" do
     @map.update("b" => 254, "c" => @container.new([300]))
-    @map["a"].should eql(@container.new([100]))
-    @map["b"].should eql(@container.new([200, 300, 254]))
-    @map["c"].should eql(@container.new([300]))
+    expect(@map["a"]).to eql(@container.new([100]))
+    expect(@map["b"]).to eql(@container.new([200, 300, 254]))
+    expect(@map["c"]).to eql(@container.new([300]))
 
     klass = @map.class
     @map.update(klass[@container.new, {"a" => @container.new([400, 500]), "c" => 600}])
-    @map["a"].should eql(@container.new([100, 400, 500]))
-    @map["b"].should eql(@container.new([200, 300, 254]))
-    @map["c"].should eql(@container.new([300, 600]))
+    expect(@map["a"]).to eql(@container.new([100, 400, 500]))
+    expect(@map["b"]).to eql(@container.new([200, 300, 254]))
+    expect(@map["c"]).to eql(@container.new([300, 600]))
   end
 
   it "should reject key pairs on copy of the map" do
     map = @map.reject { |key, value| key >= "b" }
-    map["b"].should eql(@container.new)
-    @map["b"].should eql(@container.new([200, 300]))
+    expect(map["b"]).to eql(@container.new)
+    expect(@map["b"]).to eql(@container.new([200, 300]))
   end
 
   it "should reject value pairs on copy of the map" do
     map = @map.reject { |key, value| value >= 300 }
-    map["b"].should eql(@container.new([200]))
-    @map["b"].should eql(@container.new([200, 300]))
+    expect(map["b"]).to eql(@container.new([200]))
+    expect(@map["b"]).to eql(@container.new([200, 300]))
   end
 
   it "should reject key pairs" do
-    @map.reject! { |key, value| key >= "b" }.should eql(@map)
-    @map["a"].should eql(@container.new([100]))
-    @map["b"].should eql(@container.new)
+    expect(@map.reject! { |key, value| key >= "b" }).to eql(@map)
+    expect(@map["a"]).to eql(@container.new([100]))
+    expect(@map["b"]).to eql(@container.new)
 
-    @map.reject! { |key, value| key >= "z" }.should eql(nil)
+    expect(@map.reject! { |key, value| key >= "z" }).to eql(nil)
   end
 
   it "should reject value pairs" do
-    @map.reject! { |key, value| value >= 300 }.should eql(@map)
-    @map["a"].should eql(@container.new([100]))
-    @map["b"].should eql(@container.new([200]))
+    expect(@map.reject! { |key, value| value >= 300 }).to eql(@map)
+    expect(@map["a"]).to eql(@container.new([100]))
+    expect(@map["b"]).to eql(@container.new([200]))
 
-    @map.reject! { |key, value| key >= "z" }.should eql(nil)
+    expect(@map.reject! { |key, value| key >= "z" }).to eql(nil)
   end
 
   it "should select key/value pairs" do
-    @map.select { |k, v| k > "a" }.should eql(Multimap["b", [200, 300]])
-    @map.select { |k, v| v < 200 }.should eql(Multimap["a", 100])
+    expect(@map.select { |k, v| k > "a" }).to eql(Multimap["b", [200, 300]])
+    expect(@map.select { |k, v| v < 200 }).to eql(Multimap["a", 100])
   end
 
   it "should convert to hash" do
-    @map.to_hash["a"].should eql(@container.new([100]))
-    @map.to_hash["b"].should eql(@container.new([200, 300]))
-    @map.to_hash.should_not equal(@map)
+    expect(@map.to_hash["a"]).to eql(@container.new([100]))
+    expect(@map.to_hash["b"]).to eql(@container.new([200, 300]))
+    expect(@map.to_hash).to_not equal(@map)
   end
 
   it "should return all containers" do
-    @map.containers.should sorted_eql([@container.new([100]), @container.new([200, 300])])
+    expect(@map.containers).to sorted_eql([@container.new([100]), @container.new([200, 300])])
   end
 
   it "should return all values" do
-    @map.values.should sorted_eql([100, 200, 300])
+    expect(@map.values).to sorted_eql([100, 200, 300])
   end
 
   it "should return return values at keys" do
-    @map.values_at("a", "b").should eql([@container.new([100]), @container.new([200, 300])])
+    expect(@map.values_at("a", "b")).to eql([@container.new([100]), @container.new([200, 300])])
   end
 
   it "should marshal hash" do
     data = Marshal.dump(@map)
-    Marshal.load(data).should eql(@map)
+    expect(Marshal.load(data)).to eql(@map)
   end
 
   it "should dump yaml" do
     require 'yaml'
 
     data = YAML.dump(@map)
-    YAML.load(data).should eql(@map)
+    expect(YAML.load(data)).to eql(@map)
   end
 end

--- a/lib/multimap/spec/multiset_spec.rb
+++ b/lib/multimap/spec/multiset_spec.rb
@@ -5,156 +5,156 @@ describe Multiset do
 
   it "should return the multiplicity of the element" do
     set = Multiset.new([:a, :a, :b, :b, :b, :c])
-    set.multiplicity(:a).should eql(2)
-    set.multiplicity(:b).should eql(3)
-    set.multiplicity(:c).should eql(1)
+    expect(set.multiplicity(:a)).to eql(2)
+    expect(set.multiplicity(:b)).to eql(3)
+    expect(set.multiplicity(:c)).to eql(1)
   end
 
   it "should return the cardinality of the set" do
     set = Multiset.new([:a, :a, :b, :b, :b, :c])
-    set.cardinality.should eql(6)
+    expect(set.cardinality).to eql(6)
   end
 
   it "should be eql" do
     s1 = Multiset.new([:a, :b])
     s2 = Multiset.new([:b, :a])
-    s1.should eql(s2)
+    expect(s1).to eql(s2)
 
     s1 = Multiset.new([:a, :a])
     s2 = Multiset.new([:a])
-    s1.should_not eql(s2)
+    expect(s1).to_not eql(s2)
   end
 
   it "should replace the contents of the set" do
     set = Multiset[:a, :b, :b, :c]
     ret = set.replace(Multiset[:a, :a, :b, :b, :b, :c])
 
-    set.should equal(ret)
-    set.should eql(Multiset[:a, :a, :b, :b, :b, :c])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[:a, :a, :b, :b, :b, :c])
 
     set = Multiset[:a, :b, :b, :c]
     ret = set.replace([:a, :a, :b, :b, :b, :c])
 
-    set.should equal(ret)
-    set.should eql(Multiset[:a, :a, :b, :b, :b, :c])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[:a, :a, :b, :b, :b, :c])
   end
 
   it "should return true if the set is a superset of the given set" do
     set = Multiset[1, 2, 2, 3]
 
-    set.superset?(Multiset[]).should be_true
-    set.superset?(Multiset[1, 2]).should be_true
-    set.superset?(Multiset[1, 2, 3]).should be_true
-    set.superset?(Multiset[1, 2, 2, 3]).should be_true
-    set.superset?(Multiset[1, 2, 2, 2]).should be_false
-    set.superset?(Multiset[1, 2, 3, 4]).should be_false
-    set.superset?(Multiset[1, 4]).should be_false
+    expect(set.superset?(Multiset[])).to be_true
+    expect(set.superset?(Multiset[1, 2])).to be_true
+    expect(set.superset?(Multiset[1, 2, 3])).to be_true
+    expect(set.superset?(Multiset[1, 2, 2, 3])).to be_true
+    expect(set.superset?(Multiset[1, 2, 2, 2])).to be_false
+    expect(set.superset?(Multiset[1, 2, 3, 4])).to be_false
+    expect(set.superset?(Multiset[1, 4])).to be_false
   end
 
   it "should return true if the set is a proper superset of the given set" do
     set = Multiset[1, 2, 2, 3, 3]
 
-    set.proper_superset?(Multiset[]).should be_true
-    set.proper_superset?(Multiset[1, 2]).should be_true
-    set.proper_superset?(Multiset[1, 2, 3]).should be_true
-    set.proper_superset?(Multiset[1, 2, 2, 3, 3]).should be_false
-    set.proper_superset?(Multiset[1, 2, 2, 2]).should be_false
-    set.proper_superset?(Multiset[1, 2, 3, 4]).should be_false
-    set.proper_superset?(Multiset[1, 4]).should be_false
+    expect(set.proper_superset?(Multiset[])).to be_true
+    expect(set.proper_superset?(Multiset[1, 2])).to be_true
+    expect(set.proper_superset?(Multiset[1, 2, 3])).to be_true
+    expect(set.proper_superset?(Multiset[1, 2, 2, 3, 3])).to be_false
+    expect(set.proper_superset?(Multiset[1, 2, 2, 2])).to be_false
+    expect(set.proper_superset?(Multiset[1, 2, 3, 4])).to be_false
+    expect(set.proper_superset?(Multiset[1, 4])).to be_false
   end
 
   it "should return true if the set is a subset of the given set" do
     set = Multiset[1, 2, 2, 3]
 
-    set.subset?(Multiset[1, 2, 2, 3, 4]).should be_true
-    set.subset?(Multiset[1, 2, 2, 3, 3]).should be_true
-    set.subset?(Multiset[1, 2, 2, 3]).should be_true
-    set.subset?(Multiset[1, 2, 3]).should be_false
-    set.subset?(Multiset[1, 2, 2]).should be_false
-    set.subset?(Multiset[1, 2, 3]).should be_false
-    set.subset?(Multiset[]).should be_false
+    expect(set.subset?(Multiset[1, 2, 2, 3, 4])).to be_true
+    expect(set.subset?(Multiset[1, 2, 2, 3, 3])).to be_true
+    expect(set.subset?(Multiset[1, 2, 2, 3])).to be_true
+    expect(set.subset?(Multiset[1, 2, 3])).to be_false
+    expect(set.subset?(Multiset[1, 2, 2])).to be_false
+    expect(set.subset?(Multiset[1, 2, 3])).to be_false
+    expect(set.subset?(Multiset[])).to be_false
   end
 
   it "should return true if the set is a proper subset of the given set" do
     set = Multiset[1, 2, 2, 3, 3]
 
-    set.proper_subset?(Multiset[1, 2, 2, 3, 3, 4]).should be_true
-    set.proper_subset?(Multiset[1, 2, 2, 3, 3]).should be_false
-    set.proper_subset?(Multiset[1, 2, 3]).should be_false
-    set.proper_subset?(Multiset[1, 2, 2]).should be_false
-    set.proper_subset?(Multiset[1, 2, 3]).should be_false
-    set.proper_subset?(Multiset[]).should be_false
+    expect(set.proper_subset?(Multiset[1, 2, 2, 3, 3, 4])).to be_true
+    expect(set.proper_subset?(Multiset[1, 2, 2, 3, 3])).to be_false
+    expect(set.proper_subset?(Multiset[1, 2, 3])).to be_false
+    expect(set.proper_subset?(Multiset[1, 2, 2])).to be_false
+    expect(set.proper_subset?(Multiset[1, 2, 3])).to be_false
+    expect(set.proper_subset?(Multiset[])).to be_false
   end
 
   it "should delete the objects from the set and return self" do
     set = Multiset[1, 2, 2, 3]
 
     ret = set.delete(4)
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 2, 3])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 2, 3])
 
     ret = set.delete(2)
-    set.should eql(ret)
-    set.should eql(Multiset[1, 3])
+    expect(set).to eql(ret)
+    expect(set).to eql(Multiset[1, 3])
   end
 
   it "should delete the number objects from the set and return self" do
     set = Multiset[1, 2, 2, 3]
 
     ret = set.delete(2, 1)
-    set.should eql(ret)
-    set.should eql(Multiset[1, 2, 3])
+    expect(set).to eql(ret)
+    expect(set).to eql(Multiset[1, 2, 3])
   end
 
   it "should merge the elements of the given enumerable object to the set and return self" do
     set = Multiset[1, 2, 3]
     ret = set.merge([2, 4, 5])
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 2, 3, 4, 5])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 2, 3, 4, 5])
 
     set = Multiset[1, 2, 3]
     ret = set.merge(Multiset[2, 4, 5])
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 2, 3, 4, 5])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 2, 3, 4, 5])
   end
 
   it "should delete every element that appears in the given enumerable object and return self" do
     set = Multiset[1, 2, 2, 3]
     ret = set.subtract([2, 4, 6])
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 3])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 3])
   end
 
   it "should return a new set containing elements common to the set and the given enumerable object" do
     set = Multiset[1, 2, 2, 3, 4]
 
     ret = set & [2, 2, 4, 5]
-    set.should_not equal(ret)
-    ret.should eql(Multiset[2, 2, 4])
+    expect(set).to_not equal(ret)
+    expect(ret).to eql(Multiset[2, 2, 4])
 
     set = Multiset[1, 2, 3]
 
     ret = set & [1, 2, 2, 2]
-    set.should_not equal(ret)
-    ret.should eql(Multiset[1, 2])
+    expect(set).to_not equal(ret)
+    expect(ret).to eql(Multiset[1, 2])
   end
 
   it "should return a new set containing elements exclusive between the set and the given enumerable object" do
     set = Multiset[1, 2, 3, 4, 5]
     ret = set ^ [2, 4, 5, 5]
-    set.should_not equal(ret)
-    ret.should eql(Multiset[1, 3, 5])
+    expect(set).to_not equal(ret)
+    expect(ret).to eql(Multiset[1, 3, 5])
 
     set = Multiset[1, 2, 4, 5, 5]
     ret = set ^ [2, 3, 4, 5]
-    set.should_not equal(ret)
-    ret.should eql(Multiset[1, 3, 5])
+    expect(set).to_not equal(ret)
+    expect(ret).to eql(Multiset[1, 3, 5])
   end
 
   it "should marshal set" do
     set = Multiset[1, 2, 3, 4, 5]
     data = Marshal.dump(set)
-    Marshal.load(data).should eql(set)
+    expect(Marshal.load(data)).to eql(set)
   end
 
   it "should dump yaml" do
@@ -162,7 +162,7 @@ describe Multiset do
 
     set = Multiset[1, 2, 3, 4, 5]
     data = YAML.dump(set)
-    YAML.load(data).should eql(set)
+    expect(YAML.load(data)).to eql(set)
   end
 end
 
@@ -174,11 +174,11 @@ describe Multiset, "with inital values" do
   end
 
   it "should return the multiplicity of the element" do
-    @set.multiplicity(1).should eql(1)
-    @set.multiplicity(2).should eql(1)
+    expect(@set.multiplicity(1)).to eql(1)
+    expect(@set.multiplicity(2)).to eql(1)
   end
 
   it "should return the cardinality of the set" do
-    @set.cardinality.should eql(2)
+    expect(@set.cardinality).to eql(2)
   end
 end

--- a/lib/multimap/spec/nested_multimap_spec.rb
+++ b/lib/multimap/spec/nested_multimap_spec.rb
@@ -10,54 +10,54 @@ describe NestedMultimap, "with inital values" do
 
   it "should set value at nested key" do
     @map["foo", "bar", "baz"] = 100
-    @map["foo", "bar", "baz"].should eql([100])
+    expect(@map["foo", "bar", "baz"]).to eql([100])
   end
 
   it "should allow nil keys to be set" do
     @map["b", nil] = 400
     @map["b", "c"] = 500
 
-    @map["a"].should eql([100])
-    @map["b"].should eql([200, 300])
-    @map["b", nil].should eql([200, 300, 400])
-    @map["b", "c"].should eql([200, 300, 500])
+    expect(@map["a"]).to eql([100])
+    expect(@map["b"]).to eql([200, 300])
+    expect(@map["b", nil]).to eql([200, 300, 400])
+    expect(@map["b", "c"]).to eql([200, 300, 500])
   end
 
   it "should treat missing keys as append to all" do
     @map[] = 400
-    @map["a"].should eql([100, 400])
-    @map["b"].should eql([200, 300, 400])
-    @map["c"].should eql([400])
-    @map[nil].should eql([400])
+    expect(@map["a"]).to eql([100, 400])
+    expect(@map["b"]).to eql([200, 300, 400])
+    expect(@map["c"]).to eql([400])
+    expect(@map[nil]).to eql([400])
   end
 
   it "should append the value to default containers" do
     @map << 400
-    @map["a"].should eql([100, 400])
-    @map["b"].should eql([200, 300, 400])
-    @map["c"].should eql([400])
-    @map[nil].should eql([400])
+    expect(@map["a"]).to eql([100, 400])
+    expect(@map["b"]).to eql([200, 300, 400])
+    expect(@map["c"]).to eql([400])
+    expect(@map[nil]).to eql([400])
   end
 
   it "should append the value to all containers" do
     @map << 500
-    @map["a"].should eql([100, 500])
-    @map["b"].should eql([200, 300, 500])
-    @map[nil].should eql([500])
+    expect(@map["a"]).to eql([100, 500])
+    expect(@map["b"]).to eql([200, 300, 500])
+    expect(@map[nil]).to eql([500])
   end
 
   it "default values should be copied to new containers" do
     @map << 300
     @map["x"] = 100
-    @map["x"].should eql([300, 100])
+    expect(@map["x"]).to eql([300, 100])
   end
 
   it "should list all containers" do
-    @map.containers.should sorted_eql([[100], [200, 300]])
+    expect(@map.containers).to sorted_eql([[100], [200, 300]])
   end
 
   it "should list all values" do
-    @map.values.should sorted_eql([100, 200, 300])
+    expect(@map.values).to sorted_eql([100, 200, 300])
   end
 end
 
@@ -72,52 +72,52 @@ describe NestedMultimap, "with nested values" do
   end
 
   it "should retrieve container of values for key" do
-    @map["a"].should eql([100])
-    @map["b"].should eql([200])
-    @map["c"].should eql([500])
-    @map["a", "b"].should eql([100])
-    @map["b", "c"].should eql([200, 300])
-    @map["c", "e"].should eql([400, 500])
+    expect(@map["a"]).to eql([100])
+    expect(@map["b"]).to eql([200])
+    expect(@map["c"]).to eql([500])
+    expect(@map["a", "b"]).to eql([100])
+    expect(@map["b", "c"]).to eql([200, 300])
+    expect(@map["c", "e"]).to eql([400, 500])
   end
 
   it "should append the value to default containers" do
     @map << 600
-    @map["a"].should eql([100, 600])
-    @map["b"].should eql([200, 600])
-    @map["c"].should eql([500, 600])
-    @map["a", "b"].should eql([100, 600])
-    @map["b", "c"].should eql([200, 300, 600])
-    @map["c", "e"].should eql([400, 500, 600])
-    @map[nil].should eql([600])
+    expect(@map["a"]).to eql([100, 600])
+    expect(@map["b"]).to eql([200, 600])
+    expect(@map["c"]).to eql([500, 600])
+    expect(@map["a", "b"]).to eql([100, 600])
+    expect(@map["b", "c"]).to eql([200, 300, 600])
+    expect(@map["c", "e"]).to eql([400, 500, 600])
+    expect(@map[nil]).to eql([600])
   end
 
   it "should duplicate the containers" do
     map2 = @map.dup
-    map2.should_not equal(@map)
-    map2.should eql(@map)
+    expect(map2).to_not equal(@map)
+    expect(map2).to eql(@map)
 
-    map2["a"].should eql([100])
-    map2["b"].should eql([200])
-    map2["c"].should eql([500])
-    map2["a", "b"].should eql([100])
-    map2["b", "c"].should eql([200, 300])
-    map2["c", "e"].should eql([400, 500])
+    expect(map2["a"]).to eql([100])
+    expect(map2["b"]).to eql([200])
+    expect(map2["c"]).to eql([500])
+    expect(map2["a", "b"]).to eql([100])
+    expect(map2["b", "c"]).to eql([200, 300])
+    expect(map2["c", "e"]).to eql([400, 500])
 
-    map2["a"].should_not equal(@map["a"])
-    map2["b"].should_not equal(@map["b"])
-    map2["c"].should_not equal(@map["c"])
-    map2["a", "b"].should_not equal(@map["a", "b"])
-    map2["b", "c"].should_not equal(@map["b", "c"])
-    map2["c", "e"].should_not equal(@map["c", "e"])
+    expect(map2["a"]).to_not equal(@map["a"])
+    expect(map2["b"]).to_not equal(@map["b"])
+    expect(map2["c"]).to_not equal(@map["c"])
+    expect(map2["a", "b"]).to_not equal(@map["a", "b"])
+    expect(map2["b", "c"]).to_not equal(@map["b", "c"])
+    expect(map2["c", "e"]).to_not equal(@map["c", "e"])
 
-    map2.default.should_not equal(@map.default)
-    map2.default.should eql(@map.default)
+    expect(map2.default).to_not equal(@map.default)
+    expect(map2.default).to eql(@map.default)
   end
 
   it "should iterate over each key/value pair and yield an array" do
     a = []
     @map.each { |pair| a << pair }
-    a.should sorted_eql([
+    expect(a).to sorted_eql([
       ["a", 100],
       [["b", "c"], 200],
       [["b", "c"], 300],
@@ -129,7 +129,7 @@ describe NestedMultimap, "with nested values" do
   it "should iterate over each key/container" do
     a = []
     @map.each_association { |key, container| a << [key, container] }
-    a.should sorted_eql([
+    expect(a).to sorted_eql([
       ["a", [100]],
       [["b", "c"], [200, 300]],
       [["c", "e"], [400, 500]]
@@ -139,7 +139,7 @@ describe NestedMultimap, "with nested values" do
   it "should iterate over each container plus the default" do
     a = []
     @map.each_container_with_default { |container| a << container }
-    a.should sorted_eql([
+    expect(a).to sorted_eql([
       [100],
       [200, 300],
       [200],
@@ -152,13 +152,13 @@ describe NestedMultimap, "with nested values" do
   it "should iterate over each key" do
     a = []
     @map.each_key { |key| a << key }
-    a.should sorted_eql(["a", ["b", "c"], ["b", "c"], ["c", "e"], ["c", "e"]])
+    expect(a).to sorted_eql(["a", ["b", "c"], ["b", "c"], ["c", "e"], ["c", "e"]])
   end
 
   it "should iterate over each key/value pair and yield the pair" do
     h = {}
     @map.each_pair { |key, value| (h[key] ||= []) << value }
-    h.should eql({
+    expect(h).to eql({
       "a" => [100],
       ["c", "e"] => [400, 500],
       ["b", "c"] => [200, 300]
@@ -168,23 +168,23 @@ describe NestedMultimap, "with nested values" do
   it "should iterate over each value" do
     a = []
     @map.each_value { |value| a << value }
-    a.should sorted_eql([100, 200, 300, 400, 500])
+    expect(a).to sorted_eql([100, 200, 300, 400, 500])
   end
 
   it "should list all containers" do
-    @map.containers.should sorted_eql([[100], [200, 300], [400, 500]])
+    expect(@map.containers).to sorted_eql([[100], [200, 300], [400, 500]])
   end
 
   it "should list all containers plus the default" do
-    @map.containers_with_default.should sorted_eql([[100], [200, 300], [200], [400, 500], [500], []])
+    expect(@map.containers_with_default).to sorted_eql([[100], [200, 300], [200], [400, 500], [500], []])
   end
 
   it "should return array of keys" do
-    @map.keys.should eql(["a", ["b", "c"], ["b", "c"], ["c", "e"], ["c", "e"]])
+    expect(@map.keys).to eql(["a", ["b", "c"], ["b", "c"], ["c", "e"], ["c", "e"]])
   end
 
   it "should list all values" do
-    @map.values.should sorted_eql([100, 200, 300, 400, 500])
+    expect(@map.values).to sorted_eql([100, 200, 300, 400, 500])
   end
 end
 

--- a/lib/multimap/spec/set_examples.rb
+++ b/lib/multimap/spec/set_examples.rb
@@ -4,16 +4,16 @@ shared_examples_for Set do
     Multiset[nil]
     Multiset[1, 2, 3]
 
-    Multiset[].size.should eql(0)
-    Multiset[nil].size.should eql(1)
-    Multiset[[]].size.should eql(1)
-    Multiset[[nil]].size.should eql(1)
+    expect(Multiset[].size).to eql(0)
+    expect(Multiset[nil].size).to eql(1)
+    expect(Multiset[[]].size).to eql(1)
+    expect(Multiset[[nil]].size).to eql(1)
 
     set = Multiset[2, 4, 6, 4]
-    Multiset.new([2, 4, 6]).should_not eql(set)
+    expect(Multiset.new([2, 4, 6])).to_not eql(set)
 
     set = Multiset[2, 4, 6, 4]
-    Multiset.new([2, 4, 6, 4]).should eql(set)
+    expect(Multiset.new([2, 4, 6, 4])).to eql(set)
   end
 
   it "should create a new set containing the elements of the given enumerable object" do
@@ -23,247 +23,247 @@ shared_examples_for Set do
     Multiset.new([1, 2])
     Multiset.new('a'..'c')
 
-    lambda { Multiset.new(false) }.should raise_error
-    lambda { Multiset.new(1) }.should raise_error
-    lambda { Multiset.new(1, 2) }.should raise_error
+    expect(lambda { Multiset.new(false) }).to raise_error
+    expect(lambda { Multiset.new(1) }).to raise_error
+    expect(lambda { Multiset.new(1, 2) }).to raise_error
 
-    Multiset.new().size.should eql(0)
-    Multiset.new(nil).size.should eql(0)
-    Multiset.new([]).size.should eql(0)
-    Multiset.new([nil]).size.should eql(1)
+    expect(Multiset.new().size).to eql(0)
+    expect(Multiset.new(nil).size).to eql(0)
+    expect(Multiset.new([]).size).to eql(0)
+    expect(Multiset.new([nil]).size).to eql(1)
 
     ary = [2, 4, 6, 4]
     set = Multiset.new(ary)
     ary.clear
-    set.should_not be_empty
-    set.size.should eql(4)
+    expect(set).to_not be_empty
+    expect(set.size).to eql(4)
 
     ary = [1, 2, 3]
 
     s = Multiset.new(ary) { |o| o * 2 }
-    [2, 4, 6].should eql(s.sort)
+    expect([2, 4, 6]).to eql(s.sort)
   end
 
   it "should duplicate set" do
     set1 = Multiset[1, 2]
     set2 = set1.dup
 
-    set1.should_not equal(set2)
+    expect(set1).to_not equal(set2)
 
-    set1.should eql(set2)
+    expect(set1).to eql(set2)
 
     set1.add(3)
 
-    set1.should_not eql(set2)
+    expect(set1).to_not eql(set2)
   end
 
   it "should return the number of elements" do
-    Multiset[].size.should eql(0)
-    Multiset[1, 2].size.should eql(2)
-    Multiset[1, 2, 1].size.should eql(3)
+    expect(Multiset[].size).to eql(0)
+    expect(Multiset[1, 2].size).to eql(2)
+    expect(Multiset[1, 2, 1].size).to eql(3)
   end
 
   it "should return true if the set contains no elements" do
-    Multiset[].should be_empty
-    Multiset[1, 2].should_not be_empty
+    expect(Multiset[]).to be_empty
+    expect(Multiset[1, 2]).to_not be_empty
   end
 
   it "should remove all elements and returns self" do
     set = Multiset[1, 2]
     ret = set.clear
 
-    set.should equal(ret)
-    set.should be_empty
+    expect(set).to equal(ret)
+    expect(set).to be_empty
   end
 
   it "should replaces the contents of the set with the contents of the given enumerable object and returns self" do
     set = Multiset[1, 2]
     ret = set.replace('a'..'c')
 
-    set.should equal(ret)
-    set.should eql(Multiset['a', 'b', 'c'])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset['a', 'b', 'c'])
   end
 
   it "should convert the set to an array" do
     set = Multiset[1, 2, 3, 2]
     ary = set.to_a
 
-    ary.sort.should eql([1, 2, 2, 3])
+    expect(ary.sort).to eql([1, 2, 2, 3])
   end
 
   it "should return true if the set contains the given object" do
     set = Multiset[1, 2, 3]
 
-    set.include?(1).should be_true
-    set.include?(2).should be_true
-    set.include?(3).should be_true
-    set.include?(0).should be_false
-    set.include?(nil).should be_false
+    expect(set.include?(1)).to be_true
+    expect(set.include?(2)).to be_true
+    expect(set.include?(3)).to be_true
+    expect(set.include?(0)).to be_false
+    expect(set.include?(nil)).to be_false
 
     set = Multiset["1", nil, "2", nil, "0", "1", false]
-    set.include?(nil).should be_true
-    set.include?(false).should be_true
-    set.include?("1").should be_true
-    set.include?(0).should be_false
-    set.include?(true).should be_false
+    expect(set.include?(nil)).to be_true
+    expect(set.include?(false)).to be_true
+    expect(set.include?("1")).to be_true
+    expect(set.include?(0)).to be_false
+    expect(set.include?(true)).to be_false
   end
 
   it "should return true if the set is a superset of the given set" do
     set = Multiset[1, 2, 3]
 
-    lambda { set.superset?() }.should raise_error
-    lambda { set.superset?(2) }.should raise_error
-    lambda { set.superset?([2]) }.should raise_error
+    expect(lambda { set.superset?() }).to raise_error
+    expect(lambda { set.superset?(2) }).to raise_error
+    expect(lambda { set.superset?([2]) }).to raise_error
 
-    set.superset?(Multiset[]).should be_true
-    set.superset?(Multiset[1, 2]).should be_true
-    set.superset?(Multiset[1, 2, 3]).should be_true
-    set.superset?(Multiset[1, 2, 3, 4]).should be_false
-    set.superset?(Multiset[1, 4]).should be_false
+    expect(set.superset?(Multiset[])).to be_true
+    expect(set.superset?(Multiset[1, 2])).to be_true
+    expect(set.superset?(Multiset[1, 2, 3])).to be_true
+    expect(set.superset?(Multiset[1, 2, 3, 4])).to be_false
+    expect(set.superset?(Multiset[1, 4])).to be_false
 
-    Multiset[].superset?(Multiset[]).should be_true
+    expect(Multiset[].superset?(Multiset[])).to be_true
   end
 
   it "should return true if the set is a proper superset of the given set" do
     set = Multiset[1, 2, 3]
 
-    lambda { set.proper_superset?() }.should raise_error
-    lambda { set.proper_superset?(2) }.should raise_error
-    lambda { set.proper_superset?([2]) }.should raise_error
+    expect(lambda { set.proper_superset?() }).to raise_error
+    expect(lambda { set.proper_superset?(2) }).to raise_error
+    expect(lambda { set.proper_superset?([2]) }).to raise_error
 
-    set.proper_superset?(Multiset[]).should be_true
-    set.proper_superset?(Multiset[1, 2]).should be_true
-    set.proper_superset?(Multiset[1, 2, 3]).should be_false
-    set.proper_superset?(Multiset[1, 2, 3, 4]).should be_false
-    set.proper_superset?(Multiset[1, 4]).should be_false
+    expect(set.proper_superset?(Multiset[])).to be_true
+    expect(set.proper_superset?(Multiset[1, 2])).to be_true
+    expect(set.proper_superset?(Multiset[1, 2, 3])).to be_false
+    expect(set.proper_superset?(Multiset[1, 2, 3, 4])).to be_false
+    expect(set.proper_superset?(Multiset[1, 4])).to be_false
 
-    Multiset[].proper_superset?(Multiset[]).should be_false
+    expect(Multiset[].proper_superset?(Multiset[])).to be_false
   end
 
   it "should return true if the set is a subset of the given set" do
     set = Multiset[1, 2, 3]
 
-    lambda { set.subset?() }.should raise_error
-    lambda { set.subset?(2) }.should raise_error
-    lambda { set.subset?([2]) }.should raise_error
+    expect(lambda { set.subset?() }).to raise_error
+    expect(lambda { set.subset?(2) }).to raise_error
+    expect(lambda { set.subset?([2]) }).to raise_error
 
-    set.subset?(Multiset[1, 2, 3, 4]).should be_true
-    set.subset?(Multiset[1, 2, 3]).should be_true
-    set.subset?(Multiset[1, 2]).should be_false
-    set.subset?(Multiset[]).should be_false
+    expect(set.subset?(Multiset[1, 2, 3, 4])).to be_true
+    expect(set.subset?(Multiset[1, 2, 3])).to be_true
+    expect(set.subset?(Multiset[1, 2])).to be_false
+    expect(set.subset?(Multiset[])).to be_false
 
-    Multiset[].subset?(Multiset[1]).should be_true
-    Multiset[].subset?(Multiset[]).should be_true
+    expect(Multiset[].subset?(Multiset[1])).to be_true
+    expect(Multiset[].subset?(Multiset[])).to be_true
   end
 
   it "should return true if the set is a proper subset of the given set" do
     set = Multiset[1, 2, 3]
 
-    lambda { set.proper_subset?() }.should raise_error
-    lambda { set.proper_subset?(2) }.should raise_error
-    lambda { set.proper_subset?([2]) }.should raise_error
+    expect(lambda { set.proper_subset?() }).to raise_error
+    expect(lambda { set.proper_subset?(2) }).to raise_error
+    expect(lambda { set.proper_subset?([2]) }).to raise_error
 
-    set.proper_subset?(Multiset[1, 2, 3, 4]).should be_true
-    set.proper_subset?(Multiset[1, 2, 3]).should be_false
-    set.proper_subset?(Multiset[1, 2]).should be_false
-    set.proper_subset?(Multiset[]).should be_false
+    expect(set.proper_subset?(Multiset[1, 2, 3, 4])).to be_true
+    expect(set.proper_subset?(Multiset[1, 2, 3])).to be_false
+    expect(set.proper_subset?(Multiset[1, 2])).to be_false
+    expect(set.proper_subset?(Multiset[])).to be_false
 
-    Multiset[].proper_subset?(Multiset[]).should be_false
+    expect(Multiset[].proper_subset?(Multiset[])).to be_false
   end
 
   it "should add the given object to the set and return self" do
     set = Multiset[1, 2, 3]
 
     ret = set.add(2)
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 2, 3])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 2, 3])
 
     ret = set.add(4)
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 2, 3, 4])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 2, 3, 4])
   end
 
   it "should delete the given object from the set and return self" do
     set = Multiset[1, 2, 3]
 
     ret = set.delete(4)
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 3])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 3])
 
     ret = set.delete(2)
-    set.should eql(ret)
-    set.should eql(Multiset[1, 3])
+    expect(set).to eql(ret)
+    expect(set).to eql(Multiset[1, 3])
   end
 
   it "should delete every element of the set for which block evaluates to true, and return self" do
     set = Multiset.new(1..10)
     ret = set.delete_if { |i| i > 10 }
-    set.should equal(ret)
-    set.should eql(Multiset.new(1..10))
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset.new(1..10))
 
     set = Multiset.new(1..10)
     ret = set.delete_if { |i| i % 3 == 0 }
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 4, 5, 7, 8, 10])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 4, 5, 7, 8, 10])
   end
 
   it "should deletes every element of the set for which block evaluates to true but return nil if no changes were made" do
     set = Multiset.new(1..10)
 
     ret = set.reject! { |i| i > 10 }
-    ret.should be_nil
-    set.should eql(Multiset.new(1..10))
+    expect(ret).to be_nil
+    expect(set).to eql(Multiset.new(1..10))
 
     ret = set.reject! { |i| i % 3 == 0 }
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 4, 5, 7, 8, 10])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 4, 5, 7, 8, 10])
   end
 
   it "should merge the elements of the given enumerable object to the set and return self" do
     set = Multiset[1, 2, 3]
 
     ret = set.merge([2, 4, 6])
-    set.should equal(ret)
-    set.should eql(Multiset[1, 2, 2, 3, 4, 6])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 2, 2, 3, 4, 6])
   end
 
   it "should delete every element that appears in the given enumerable object and return self" do
     set = Multiset[1, 2, 3]
 
     ret = set.subtract([2, 4, 6])
-    set.should equal(ret)
-    set.should eql(Multiset[1, 3])
+    expect(set).to equal(ret)
+    expect(set).to eql(Multiset[1, 3])
   end
 
   it "should return a new set built by merging the set and the elements of the given enumerable object" do
     set = Multiset[1, 2, 3]
 
     ret = set + [2, 4, 6]
-    set.should_not equal(ret)
-    ret.should eql(Multiset[1, 2, 2, 3, 4, 6])
+    expect(set).to_not equal(ret)
+    expect(ret).to eql(Multiset[1, 2, 2, 3, 4, 6])
   end
 
   it "should return a new set built by duplicating the set, removing every element that appears in the given enumerable object" do
     set = Multiset[1, 2, 3]
 
     ret = set - [2, 4, 6]
-    set.should_not equal(ret)
-    ret.should eql(Multiset[1, 3])
+    expect(set).to_not equal(ret)
+    expect(ret).to eql(Multiset[1, 3])
   end
 
   it "should return a new set containing elements common to the set and the given enumerable object" do
     set = Multiset[1, 2, 3, 4]
 
     ret = set & [2, 4, 6]
-    set.should_not equal(ret)
-    ret.should eql(Multiset[2, 4])
+    expect(set).to_not equal(ret)
+    expect(ret).to eql(Multiset[2, 4])
   end
 
   it "should return a new set containing elements exclusive between the set and the given enumerable object" do
     set = Multiset[1, 2, 3, 4]
     ret = set ^ [2, 4, 5]
-    set.should_not equal(ret)
-    ret.should eql(Multiset[1, 3, 5])
+    expect(set).to_not equal(ret)
+    expect(ret).to eql(Multiset[1, 3, 5])
   end
 end
 
@@ -271,31 +271,31 @@ shared_examples_for Set, "with inital values [1, 2]" do
   it "should add element to set" do
     @set.add("foo")
 
-    @set.include?(1).should be_true
-    @set.include?(2).should be_true
-    @set.include?("foo").should be_true
+    expect(@set.include?(1)).to be_true
+    expect(@set.include?(2)).to be_true
+    expect(@set.include?("foo")).to be_true
   end
 
   it "should merge elements into the set" do
     @set.merge([2, 6])
 
-    @set.include?(1).should be_true
-    @set.include?(2).should be_true
-    @set.include?(2).should be_true
-    @set.include?(6).should be_true
+    expect(@set.include?(1)).to be_true
+    expect(@set.include?(2)).to be_true
+    expect(@set.include?(2)).to be_true
+    expect(@set.include?(6)).to be_true
   end
 
   it "should iterate over all the values in the set" do
     a = []
     @set.each { |o| a << o }
-    a.should eql([1, 2])
+    expect(a).to eql([1, 2])
   end
 
   it "should convert to an array" do
-    @set.to_a.should eql([1, 2])
+    expect(@set.to_a).to eql([1, 2])
   end
 
   it "should convert to a set" do
-    @set.to_set.to_a.should eql([1, 2])
+    expect(@set.to_set.to_a).to eql([1, 2])
   end
 end

--- a/lib/multimap/spec/spec_helper.rb
+++ b/lib/multimap/spec/spec_helper.rb
@@ -11,11 +11,11 @@ Spec::Matchers.define :sorted_eql do |expected|
   if defined? Rubinius
     sorter = lambda { |a, b| a.hash <=> b.hash }
     match do |actual|
-      actual.sort(&sorter).should eql(expected.sort(&sorter))
+      expect(actual.sort(&sorter)).to eql(expected.sort(&sorter))
     end
   else
     match do |actual|
-      actual.should eql(expected)
+      expect(actual).to eql(expected)
     end
   end
 end

--- a/mailgun.gemspec
+++ b/mailgun.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency(%q<rest-client>, [">= 0"])
 
   gem.add_development_dependency(%q<rspec>, [">= 2"])
-  gem.add_development_dependency(%q<byebug>, [">= 0"])
-  gem.add_development_dependency(%q<vcr>, [">= 0"])
+  gem.add_development_dependency(%q<pry>, [">= 0"])
+  gem.add_development_dependency(%q<webmock>, [">= 2"])
 end

--- a/mailgun.gemspec
+++ b/mailgun.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "0.8"
 
-  gem.add_dependency(%q<rest-client>, [">= 0"])
-
   gem.add_development_dependency(%q<rspec>, [">= 2"])
   gem.add_development_dependency(%q<pry>, [">= 0"])
   gem.add_development_dependency(%q<webmock>, [">= 2"])

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -17,7 +17,7 @@ describe Mailgun::Address do
       sample_response = "{\"is_valid\":true,\"address\":\"foo@mailgun.net\",\"parts\":{\"display_name\":null,\"local_part\":\"foo\",\"domain\":\"mailgun.net\"},\"did_you_mean\":null}"
       validate_url = mailgun.addresses.send(:address_url, 'validate')
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, validate_url, {:address => @sample}).
         and_return(sample_response)
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -25,7 +25,7 @@ describe Mailgun::Base do
   describe "Mailgun.new" do
     it "Mailgun() method should return a new Mailgun object" do
       mailgun = Mailgun({:api_key => "some-junk-string"})
-      mailgun.should be_kind_of(Mailgun::Base)
+      expect(mailgun).to be_kind_of(Mailgun::Base)
     end
   end
 
@@ -35,15 +35,13 @@ describe Mailgun::Base do
     end
 
     it "Mailgun#mailboxes should return an instance of Mailgun::Mailbox" do
-      @mailgun.mailboxes.should be_kind_of(Mailgun::Mailbox)
+      expect(@mailgun.mailboxes).to be_kind_of(Mailgun::Mailbox)
     end
 
     it "Mailgun#routes should return an instance of Mailgun::Route" do
-      @mailgun.routes.should be_kind_of(Mailgun::Route)
+      expect(@mailgun.routes).to be_kind_of(Mailgun::Route)
     end
   end
-
-
 
   describe "internal helper methods" do
     before :each do
@@ -52,7 +50,7 @@ describe Mailgun::Base do
 
     describe "Mailgun#base_url" do
       it "should return https url if use_https is true" do
-      @mailgun.base_url.should == "https://api:#{Mailgun.api_key}@#{Mailgun.mailgun_host}/#{Mailgun.api_version}"
+      expect(@mailgun.base_url).to eq "https://api:#{Mailgun.api_key}@#{Mailgun.mailgun_host}/#{Mailgun.api_version}"
       end
     end
 
@@ -64,27 +62,26 @@ describe Mailgun::Base do
         Mailgun.submit :test_method, '/', :arg1=>"val1"
       end
     end
-
   end
 
   describe "configuration" do
     describe "default settings" do
       it "api_version is v2" do
-        Mailgun.api_version.should eql 'v3'
+        expect(Mailgun.api_version).to eql 'v3'
       end
       it "should use https by default" do
-        Mailgun.protocol.should == "https"
+        expect(Mailgun.protocol).to eq "https"
       end
       it "mailgun_host is 'api.mailgun.net'" do
-        Mailgun.mailgun_host.should eql 'api.mailgun.net'
+        expect(Mailgun.mailgun_host).to eql 'api.mailgun.net'
       end
 
       it "test_mode is false" do
-        Mailgun.test_mode.should eql false
+        expect(Mailgun.test_mode).to eql false
       end
 
       it "domain is not set" do
-        Mailgun.domain.should be_nil
+        expect(Mailgun.domain).to be_nil
       end
     end
 
@@ -103,26 +100,26 @@ describe Mailgun::Base do
       after(:each) { Mailgun.configure { |c| c.domain = nil } }
 
       it "allows me to set my API key easily" do
-        Mailgun.api_key.should eql 'some-api-key'
+        expect(Mailgun.api_key).to eql 'some-api-key'
       end
 
       it "allows me to set the api_version attribute" do
-        Mailgun.api_version.should eql 'v2'
+        expect(Mailgun.api_version).to eql 'v2'
       end
 
       it "allows me to set the protocol attribute" do
-        Mailgun.protocol.should eql 'https'
+        expect(Mailgun.protocol).to eql 'https'
       end
 
       it "allows me to set the mailgun_host attribute" do
-        Mailgun.mailgun_host.should eql 'api.mailgun.net'
+        expect(Mailgun.mailgun_host).to eql 'api.mailgun.net'
       end
       it "allows me to set the test_mode attribute" do
-        Mailgun.test_mode.should eql false
+        expect(Mailgun.test_mode).to eql false
       end
 
       it "allows me to set my domain easily" do
-        Mailgun.domain.should eql 'some-domain'
+        expect(Mailgun.domain).to eql 'some-domain'
       end
     end
   end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -66,7 +66,7 @@ describe Mailgun::Base do
 
   describe "configuration" do
     describe "default settings" do
-      it "api_version is v2" do
+      it "api_version is v3" do
         expect(Mailgun.api_version).to eql 'v3'
       end
       it "should use https by default" do

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -55,10 +55,16 @@ describe Mailgun::Base do
     end
 
     describe "Mailgun.submit" do
-      it "should send method and arguments to RestClient" do
-        expect(RestClient).to receive(:test_method)
-          .with('/', {:arg1=>"val1"})
+      let(:client_double) { double(Mailgun::Client) }
+
+      it "should send method and arguments to Mailgun::Client" do
+        expect(Mailgun::Client).to receive(:new)
+          .with('/')
+          .and_return(client_double)
+        expect(client_double).to receive(:test_method)
+          .with({:arg1=>"val1"})
           .and_return('{}')
+
         Mailgun.submit :test_method, '/', :arg1=>"val1"
       end
     end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -70,7 +70,7 @@ describe Mailgun::Base do
   describe "configuration" do
     describe "default settings" do
       it "api_version is v2" do
-        Mailgun.api_version.should eql 'v2'
+        Mailgun.api_version.should eql 'v3'
       end
       it "should use https by default" do
         Mailgun.protocol.should == "https"

--- a/spec/bounce_spec.rb
+++ b/spec/bounce_spec.rb
@@ -17,10 +17,10 @@ describe Mailgun::Bounce do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       bounces_url = @mailgun.bounces(@sample[:domain]).send(:bounce_url)
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, bounces_url, {}).
         and_return(sample_response)
-    
+
       @mailgun.bounces(@sample[:domain]).list
     end
   end
@@ -30,7 +30,7 @@ describe Mailgun::Bounce do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       bounces_url = @mailgun.bounces(@sample[:domain]).send(:bounce_url, @sample[:email])
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, bounces_url).
         and_return(sample_response)
 
@@ -43,7 +43,7 @@ describe Mailgun::Bounce do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       bounces_url = @mailgun.bounces(@sample[:domain]).send(:bounce_url)
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:post, bounces_url, {:address => @sample[:email]} ).
         and_return(sample_response)
 
@@ -56,7 +56,7 @@ describe Mailgun::Bounce do
       sample_response = "{\"message\"=>\"Bounced address has been removed\", \"address\"=>\"postmaster@bsample.mailgun.org\"}"
       bounces_url = @mailgun.bounces(@sample[:domain]).send(:bounce_url, @sample[:email])
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:delete, bounces_url).
         and_return(sample_response)
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -31,20 +31,60 @@ describe Mailgun::Client do
         expect(stub).to have_been_requested
       end
     end
+
+    context 'when an error happens' do
+      let(:url) { 'https://api:key@api.mailgun.net/v3/routes/123' }
+      let(:error_body) { { "message" => "Expression is missing" }.to_json }
+
+      before do
+        stub_request(:get, 'https://api.mailgun.net/v3/routes/123')
+          .with(basic_auth: ['api', 'key'])
+          .to_return(status: [400, "Bad Request"],
+                     body: error_body)
+      end
+
+      it 'raises exception that contains the error code and body' do
+        begin
+          subject.get
+        rescue => e
+          @exception = e
+        end
+
+        expect(@exception.http_code).to eq(400)
+        expect(@exception.http_body).to eq(error_body)
+      end
+    end
   end
 
   describe '#post' do
     let(:url) { 'https://api:key@api.mailgun.net/v3/routes' }
+    let(:params) { { action: ['forward', 'stop'], description: 'yolo' } }
+    let(:response) do
+      {
+        "message" => "Route has been created",
+        "route" => {
+          "actions" => [
+            "forward(\"stefan@metrilo.com\")",
+            "stop()"
+          ],
+          "created_at" => "Wed, 15 Jun 2016 07:10:09 GMT",
+          "description" => "Sample route",
+          "expression" => "match_recipient(\".*@metrilo.com\")",
+          "id" => "5760ff5163badc3a756f9d2c",
+          "priority" => 5
+        }
+      }
+    end
 
-    it 'sends a POST request with the params form-encoded' do
-      stub = stub_request(:post, 'https://api.mailgun.net/v3/routes')
+    before do
+      stub_request(:post, 'https://api.mailgun.net/v3/routes')
         .with(basic_auth: ['api', 'key'],
               body: 'action=forward&action=stop&description=yolo')
+        .to_return(body: response.to_json)
+    end
 
-      subject.post(action: ['forward', 'stop'],
-                   description: 'yolo')
-
-      expect(stub).to have_been_requested
+    it 'sends a POST request with the params form-encoded' do
+      expect(subject.post(params)).to eq(response.to_json)
     end
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+require 'webmock/rspec'
+
+describe Mailgun::Client do
+  subject { described_class.new(url) }
+
+  describe '#get' do
+    context 'without query params' do
+      let(:url) { 'https://api:key@api.mailgun.net/v3/routes' }
+
+      it 'sends a GET request to the given path' do
+        stub = stub_request(:get, 'https://api.mailgun.net/v3/routes')
+          .with(basic_auth: ['api', 'key'])
+
+        subject.get
+
+        expect(stub).to have_been_requested
+      end
+    end
+
+    context 'with query params' do
+      let(:url) { 'https://api:key@api.mailgun.net/v3/routes' }
+
+      it 'sends a GET request to the given path with the params' do
+        stub = stub_request(:get, 'https://api.mailgun.net/v3/routes?limit=10')
+          .with(basic_auth: ['api', 'key'])
+
+        subject.get(limit: 10)
+
+        expect(stub).to have_been_requested
+      end
+    end
+  end
+
+  describe '#post' do
+    let(:url) { 'https://api:key@api.mailgun.net/v3/routes' }
+
+    it 'sends a POST request with the params form-encoded' do
+      stub = stub_request(:post, 'https://api.mailgun.net/v3/routes')
+        .with(basic_auth: ['api', 'key'],
+              body: 'action=forward&action=stop&description=yolo')
+
+      subject.post(action: ['forward', 'stop'],
+                   description: 'yolo')
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#put' do
+    let(:url) { 'https://api:key@api.mailgun.net/v3/routes/123' }
+
+    it 'sends a PUT request with the params form-encoded' do
+      stub = stub_request(:put, 'https://api.mailgun.net/v3/routes/123')
+        .with(basic_auth: ['api', 'key'],
+              body: 'action=forward&action=stop&description=yolo')
+
+      subject.put(action: ['forward', 'stop'],
+                   description: 'yolo')
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#delete' do
+    let(:url) { 'https://api:key@api.mailgun.net/v3/routes/123' }
+
+    it 'sends a DELETE request with the params form-encoded' do
+      stub = stub_request(:delete, 'https://api.mailgun.net/v3/routes/123')
+        .with(basic_auth: ['api', 'key'])
+
+      subject.delete
+
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/complaint_spec.rb
+++ b/spec/complaint_spec.rb
@@ -29,7 +29,7 @@ EOF
 
       complaints_url = @mailgun.complaints(@sample[:domain]).send(:complaint_url)
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, complaints_url, {}).
         and_return(sample_response)
 
@@ -49,7 +49,7 @@ EOF
 
       complaints_url = @mailgun.complaints(@sample[:domain]).send(:complaint_url)
 
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
         .with(:post, complaints_url, {:address => @sample[:email]})
         .and_return(sample_response)
 
@@ -72,7 +72,7 @@ EOF
 
       complaints_url = @mailgun.complaints(@sample[:domain]).send(:complaint_url, @sample[:email])
 
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
         .with(:get, complaints_url)
         .and_return(sample_response)
 
@@ -92,7 +92,7 @@ EOF
 
       complaints_url = @mailgun.complaints(@sample[:domain]).send(:complaint_url, @sample[:email])
 
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
         .with(:delete, complaints_url)
         .and_return(sample_response)
 

--- a/spec/domain_spec.rb
+++ b/spec/domain_spec.rb
@@ -18,7 +18,7 @@ describe Mailgun::Domain do
       sample_response = "{\"total_count\": 1, \"items\": [{\"created_at\": \"Tue, 12 Feb 2013 20:13:49 GMT\", \"smtp_login\": \"postmaster@sample.mailgun.org\", \"name\": \"sample.mailgun.org\", \"smtp_password\": \"67bw67bz7w\" }]}"
       domains_url = @mailgun.domains.send(:domain_url)
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, domains_url, {}).
         and_return(sample_response)
 
@@ -31,7 +31,7 @@ describe Mailgun::Domain do
       sample_response = "{\"domain\": {\"created_at\": \"Tue, 12 Feb 2013 20:13:49 GMT\", \"smtp_login\": \"postmaster@bample.mailgun.org\", \"name\": \"sample.mailgun.org\", \"smtp_password\": \"67bw67bz7w\" }, \"receiving_dns_records\": [], \"sending_dns_records\": []}"
       domains_url = @mailgun.domains.send(:domain_url, @sample[:domain])
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, domains_url).
         and_return(sample_response)
 
@@ -44,7 +44,7 @@ describe Mailgun::Domain do
       sample_response = "{\"domain\": {\"created_at\": \"Tue, 12 Feb 2013 20:13:49 GMT\", \"smtp_login\": \"postmaster@sample.mailgun.org\",\"name\": \"sample.mailgun.org\",\"smtp_password\": \"67bw67bz7w\"}, \"message\": \"Domain has been created\"}"
       domains_url = @mailgun.domains.send(:domain_url)
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:post, domains_url, {:name => @sample[:domain]} ).
         and_return(sample_response)
 
@@ -57,7 +57,7 @@ describe Mailgun::Domain do
       sample_response = "{\"message\": \"Domain has been deleted\"}"
       domains_url = @mailgun.domains.send(:domain_url, @sample[:domain])
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:delete, domains_url).
         and_return(sample_response)
 

--- a/spec/helpers/mailgun_helper.rb
+++ b/spec/helpers/mailgun_helper.rb
@@ -2,8 +2,8 @@ module MailgunHelper
   def generate_request_auth(api_key, offset=0)
     timestamp = Time.now.to_i + offset * 60
     token = ([nil]*50).map { ((48..57).to_a+(65..90).to_a+(97..122).to_a).sample.chr }.join
-    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha256'), api_key, '%s%s' % [timestamp, token])
-        
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), api_key, '%s%s' % [timestamp, token])
+
     return timestamp, token, signature
   end
 end

--- a/spec/list/member_spec.rb
+++ b/spec/list/member_spec.rb
@@ -18,10 +18,10 @@ describe Mailgun::MailingList::Member do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       mailing_list_members_url = @mailgun.list_members(@sample[:list_email]).send(:list_member_url)
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, mailing_list_members_url, {}).
         and_return(sample_response)
-    
+
       @mailgun.list_members(@sample[:list_email]).list
     end
   end
@@ -30,8 +30,8 @@ describe Mailgun::MailingList::Member do
     it "should make a GET request with correct params to find given email address" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       mailing_list_members_url = @mailgun.list_members(@sample[:list_email]).send(:list_member_url, @sample[:email])
-      
-      Mailgun.should_receive(:submit).
+
+      expect(Mailgun).to receive(:submit).
         with(:get, mailing_list_members_url).
         and_return(sample_response)
 
@@ -44,7 +44,7 @@ describe Mailgun::MailingList::Member do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       mailing_list_members_url = @mailgun.list_members(@sample[:list_email]).send(:list_member_url)
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:post, mailing_list_members_url, {
           :address => @sample[:email]
         }).
@@ -57,7 +57,7 @@ describe Mailgun::MailingList::Member do
   describe "update member in list" do
     it "should make a PUT request with correct params" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:put, "#{@mailgun.list_members(@sample[:list_email]).send(:list_member_url, @sample[:email])}", {
           :address => @sample[:email]
         }).
@@ -71,7 +71,7 @@ describe Mailgun::MailingList::Member do
     it "should make a DELETE request with correct params" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       mailing_list_members_url = @mailgun.list_members(@sample[:list_email]).send(:list_member_url, @sample[:email])
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:delete, mailing_list_members_url).
         and_return(sample_response)
 

--- a/spec/list/message_spec.rb
+++ b/spec/list/message_spec.rb
@@ -16,7 +16,7 @@ describe Mailgun::Log do
     it "should make a POST request to send an email" do
 
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
       .with(:get, "#{@mailgun.lists.send(:list_url, @sample[:list_email])}")
       .and_return(sample_response)
 
@@ -29,7 +29,7 @@ describe Mailgun::Log do
         :text => "yeah, we're gonna need you to come in on friday...yeah.",
         :from => "lumberg.bill@initech.mailgun.domain"
       }
-      Mailgun.should_receive(:submit)                            \
+      expect(Mailgun).to receive(:submit)                            \
         .with(:post, @mailgun.messages.messages_url, parameters) \
         .and_return(sample_response)
 

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -16,9 +16,9 @@ describe Mailgun::MailingList do
   describe "list mailing lists" do
     it "should make a GET request with the right params" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
       .with(:get, "#{@mailgun.lists.send(:list_url)}", {}).and_return(sample_response)
-    
+
       @mailgun.lists.list
     end
   end
@@ -26,7 +26,7 @@ describe Mailgun::MailingList do
   describe "find list adress" do
     it "should make a GET request with correct params to find given email address" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
       .with(:get, "#{@mailgun.lists.send(:list_url, @sample[:list_email])}")
       .and_return(sample_response)
 
@@ -37,7 +37,7 @@ describe Mailgun::MailingList do
   describe "create list" do
     it "should make a POST request with correct params to add a given email address" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
       .with(:post, "#{@mailgun.lists.send(:list_url)}", {:address => @sample[:list_email]})
       .and_return(sample_response)
 
@@ -48,7 +48,7 @@ describe Mailgun::MailingList do
   describe "update list" do
     it "should make a PUT request with correct params" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
       .with(:put, "#{@mailgun.lists.send(:list_url, @sample[:list_email])}", {:address => @sample[:email]})
       .and_return(sample_response)
 
@@ -59,7 +59,7 @@ describe Mailgun::MailingList do
   describe "delete list" do
     it "should make a DELETE request with correct params" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
       .with(:delete, "#{@mailgun.lists.send(:list_url, @sample[:list_email])}")
       .and_return(sample_response)
 

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -16,7 +16,7 @@ describe Mailgun::Log do
     it "should make a GET request with the right params" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       log_url = @mailgun.log(@sample[:domain]).send(:log_url)
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, log_url, {}).
         and_return(sample_response)
 

--- a/spec/mailbox_spec.rb
+++ b/spec/mailbox_spec.rb
@@ -17,7 +17,7 @@ describe Mailgun::Mailbox do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       mailboxes_url = @mailgun.mailboxes(@sample[:domain]).send(:mailbox_url)
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get,mailboxes_url, {}).
         and_return(sample_response)
 
@@ -28,7 +28,7 @@ describe Mailgun::Mailbox do
   describe "create mailbox" do
     it "should make a POST request with the right params"	do
       mailboxes_url = @mailgun.mailboxes(@sample[:domain]).send(:mailbox_url)
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
         .with(:post, mailboxes_url,
           :mailbox  => @sample[:email],
           :password => @sample[:password])
@@ -41,7 +41,7 @@ describe Mailgun::Mailbox do
   describe "update mailbox" do
     it "should make a PUT request with the right params" do
       mailboxes_url = @mailgun.mailboxes(@sample[:domain]).send(:mailbox_url, @sample[:mailbox_name])
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
         .with(:put, mailboxes_url, :password => @sample[:password])
         .and_return({})
 
@@ -53,7 +53,7 @@ describe Mailgun::Mailbox do
   describe "destroy mailbox" do
     it "should make a DELETE request with the right params" do
       mailboxes_url = @mailgun.mailboxes(@sample[:domain]).send(:mailbox_url, @sample[:name])
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
         .with(:delete, mailboxes_url)
         .and_return({})
 

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -16,7 +16,7 @@ describe Mailgun::Route do
 }
 EOF.to_json
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, "#{@mailgun.routes.send(:route_url)}", {}).
         and_return(sample_response)
     end
@@ -26,7 +26,7 @@ EOF.to_json
     end
 
     it "should respond with an Array" do
-      @mailgun.routes.list.should be_kind_of(Array)
+      expect(@mailgun.routes.list).to be_kind_of(Array)
     end
   end
 
@@ -48,7 +48,7 @@ EOF.to_json
 }
 EOF
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, "#{@mailgun.routes.send(:route_url, @sample_route_id)}").
         and_return(sample_response)
 
@@ -82,7 +82,7 @@ EOF
     it "should make a PUT request with the right params" do
       options = { description: "test_route" }
 
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
         .with(:put, "#{@mailgun.routes.send(:route_url, @sample_route_id)}", { 'description' => ["test_route"] })
         .and_return("{\"id\": \"#{@sample_route_id}\"}")
       @mailgun.routes.update @sample_route_id, options
@@ -91,7 +91,7 @@ EOF
 
   describe "delete route" do
     it "should make a DELETE request with the right params" do
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:delete, "#{@mailgun.routes.send(:route_url, @sample_route_id)}").
         and_return("{\"id\": \"#{@sample_route_id}\"}")
       @mailgun.routes.destroy @sample_route_id

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -80,11 +80,10 @@ EOF
 
   describe "update route" do
     it "should make a PUT request with the right params" do
-      options = {}
-      options[:description] = "test_route"
+      options = { description: "test_route" }
 
       Mailgun.should_receive(:submit)
-        .with(:put, "#{@mailgun.routes.send(:route_url, @sample_route_id)}", instance_of(Multimap))
+        .with(:put, "#{@mailgun.routes.send(:route_url, @sample_route_id)}", { 'description' => ["test_route"] })
         .and_return("{\"id\": \"#{@sample_route_id}\"}")
       @mailgun.routes.update @sample_route_id, options
     end

--- a/spec/secure_spec.rb
+++ b/spec/secure_spec.rb
@@ -15,9 +15,9 @@ describe Mailgun::Secure do
   it "generate_request_auth helper should generate a timestamp, a token and a signature" do
     timestamp, token, signature = generate_request_auth("some-api-key")
 
-    timestamp.should_not    be_nil
-    token.length.should     == 50
-    signature.length.should == 64
+    expect(timestamp).to_not    be_nil
+    expect(token.length).to     eq 50
+    expect(signature.length).to eq 64
   end
 
   it "check_request_auth should return true for a recently generated authentication" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'simplecov'
 SimpleCov.start
 
 require "rspec"
-require "byebug"
+require "pry"
 require "mailgun"
 
 RSpec.configure do |config|

--- a/spec/unsubscribe_spec.rb
+++ b/spec/unsubscribe_spec.rb
@@ -9,7 +9,7 @@ describe Mailgun::Unsubscribe do
       :email  => "test@sample.mailgun.org",
       :name   => "test",
       :domain => "sample.mailgun.org",
-      :tag   => 'tag1' 
+      :tag   => 'tag1'
     }
   end
 
@@ -17,7 +17,7 @@ describe Mailgun::Unsubscribe do
     it "should make a GET request with the right params" do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       unsubscribes_url = @mailgun.unsubscribes(@sample[:domain]).send(:unsubscribe_url)
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, unsubscribes_url, {}).
         and_return(sample_response)
 
@@ -30,7 +30,7 @@ describe Mailgun::Unsubscribe do
       sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
       unsubscribes_url = @mailgun.unsubscribes(@sample[:domain]).send(:unsubscribe_url, @sample[:email])
 
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
         .with(:get, unsubscribes_url)
         .and_return(sample_response)
 
@@ -43,7 +43,7 @@ describe Mailgun::Unsubscribe do
       response_message = "{\"message\"=>\"Unsubscribe event has been removed\", \"address\"=>\"#{@sample[:email]}\"}"
       unsubscribes_url = @mailgun.unsubscribes(@sample[:domain]).send(:unsubscribe_url, @sample[:email])
 
-      Mailgun.should_receive(:submit)
+      expect(Mailgun).to receive(:submit)
         .with(:delete, unsubscribes_url)
         .and_return(response_message)
 
@@ -55,7 +55,7 @@ describe Mailgun::Unsubscribe do
     context "to tag" do
       it "should make a POST request with correct params to add a given email address to unsubscribe from a tag" do
         response_message = "{\"message\"=>\"Address has been added to the unsubscribes table\", \"address\"=>\"#{@sample[:email]}\"}"
-        Mailgun.should_receive(:submit)
+        expect(Mailgun).to receive(:submit)
           .with(:post, "#{@mailgun.unsubscribes(@sample[:domain]).send(:unsubscribe_url)}",{:address=>@sample[:email], :tag=>@sample[:tag]})
           .and_return(response_message)
 
@@ -68,7 +68,7 @@ describe Mailgun::Unsubscribe do
         sample_response = "{\"items\": [{\"size_bytes\": 0,  \"mailbox\": \"postmaster@bsample.mailgun.org\" }  ]}"
         unsubscribes_url = @mailgun.unsubscribes(@sample[:domain]).send(:unsubscribe_url)
 
-        Mailgun.should_receive(:submit)
+        expect(Mailgun).to receive(:submit)
           .with(:post, unsubscribes_url, {
             :address => @sample[:email], :tag => '*'
           })

--- a/spec/webhook_spec.rb
+++ b/spec/webhook_spec.rb
@@ -13,7 +13,7 @@ describe Mailgun::Webhook do
 
   describe "list avabilable webhook ids" do
     it "should return the correct ids" do
-      @mailgun.webhooks.available_ids.should =~ %w(bounce deliver drop spam unsubscribe click open).map(&:to_sym)
+      expect(@mailgun.webhooks.available_ids).to match_array %i(bounce deliver drop spam unsubscribe click open)
     end
   end
 
@@ -23,7 +23,7 @@ describe Mailgun::Webhook do
       sample_response = "{\"total_count\": 1, \"items\": [{\"webhooks\":{\"open\":{\"url\":\"http://postbin.heroku.com/860bcd65\"},\"click\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}}]}"
       webhooks_url = @mailgun.webhooks.send(:webhook_url)
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, webhooks_url).
         and_return(sample_response)
 
@@ -36,7 +36,7 @@ describe Mailgun::Webhook do
       sample_response = "{\"webhook\": {\"url\":\"http://postbin.heroku.com/860bcd65\"}"
       webhooks_url = @mailgun.webhooks.send(:webhook_url, @sample[:id])
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:get, webhooks_url).
         and_return(sample_response)
 
@@ -50,7 +50,7 @@ describe Mailgun::Webhook do
         sample_response = "{\"message\":\"Webhook has been created\",\"webhook\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}"
         webhooks_url = @mailgun.webhooks.send(:webhook_url)
 
-        Mailgun.should_receive(:submit).
+        expect(Mailgun).to receive(:submit).
           with(:post, webhooks_url, {:id => @sample[:id], :url => @sample[:url]}).
           and_return(sample_response)
 
@@ -63,7 +63,7 @@ describe Mailgun::Webhook do
         webhooks_url = @mailgun.webhooks.send(:webhook_url)
         overwritten_url = 'http://mailgun.net/webhook'
 
-        Mailgun.should_receive(:submit).
+        expect(Mailgun).to receive(:submit).
           with(:post, webhooks_url, {:id => @sample[:id], :url => overwritten_url}).
           and_return(sample_response)
 
@@ -78,7 +78,7 @@ describe Mailgun::Webhook do
         sample_response = "{\"message\":\"Webhook has been updated\",\"webhook\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}"
         webhooks_url = @mailgun.webhooks.send(:webhook_url, @sample[:id])
 
-        Mailgun.should_receive(:submit).
+        expect(Mailgun).to receive(:submit).
           with(:put, webhooks_url, {:url => @sample[:url]}).
           and_return(sample_response)
 
@@ -91,7 +91,7 @@ describe Mailgun::Webhook do
         webhooks_url = @mailgun.webhooks.send(:webhook_url, @sample[:id])
         overwritten_url = 'http://mailgun.net/webhook'
 
-        Mailgun.should_receive(:submit).
+        expect(Mailgun).to receive(:submit).
           with(:put, webhooks_url, {:url => overwritten_url}).
           and_return(sample_response)
 
@@ -105,7 +105,7 @@ describe Mailgun::Webhook do
       sample_response = "{\"message\":\"Webhook has been deleted\",\"webhook\":{\"url\":\"http://postbin.heroku.com/860bcd65\"}}"
       webhooks_url = @mailgun.webhooks.send(:webhook_url, @sample[:id])
 
-      Mailgun.should_receive(:submit).
+      expect(Mailgun).to receive(:submit).
         with(:delete, webhooks_url).
         and_return(sample_response)
 


### PR DESCRIPTION
### But why?
I was having an issue with creating routes with the mailgun + RestClient, since the parameters were not properly passed to Mailgun's API. https://gist.github.com/adamof/631bd6e02dd6f092c423c089552af712
I tried making the request with the ruby built-in Net:HTTP and it succeeded so I thought this is a good reason to get rid of the dependency on RestClient.

### What have I done
🔧 I have fixed the RSpec failures and changed the expectations to conform to the new RSpec `expect(foo).to bar`
♻️  Switched to using pry for debugging, because of the nice colour scheme, unlike `byebug` 
🔪  Removed a dependency on the rails `stringify_keys` method
🚒  Improved the error handling and raising. Previously the message containing the failure reason was not passed to the exception object. For example routes creation 400 Bad Request exceptions did not have the message "Expression is missing".
📤  Most importantly I have removed RestClient and replaced it with built-in Net::HTTP library, which is tested with WebMock to ensure that the correct requests are made.

### Further work
I have made no changes to the interface of `Mailgun::Base.submit` so that this change gets live quicker. We could stop passing the full url with auth to `submit` every time and instead just pass the path and params and take the auth and url from the config settings.

### Closing notes
I have tested this in our production environment and I've had no issues creating/updating/deleting domains, routes, messages and webhooks. 
I am open to any suggestions how to improve this, since this is my first major contribution to a public gem.