### PR TITLE
Fixes "TypeError" for all http 404 responses

### DIFF
--- a/lib/mailgun/base.rb
+++ b/lib/mailgun/base.rb
@@ -102,11 +102,7 @@ module Mailgun
         :code => error_code || nil,
         :message => error_message || nil
       )
-      if error.handle.kind_of? Mailgun::ErrorBase
-        raise error.handle
-      else
-        raise error
-      end
+      raise error.handle if error.handle
     end
   end
 

--- a/lib/mailgun/mailgun_error.rb
+++ b/lib/mailgun/mailgun_error.rb
@@ -39,7 +39,7 @@ module Mailgun
 
   class NotFound < ErrorBase
     def handle
-      return nil
+      nil
     end
   end
 


### PR DESCRIPTION
Prior to this PR, any `404` response from mailgun would cause a `TypeError: exception class/object expected` to be thrown from the mailgun gem.

The previous behavior is that 404 should return a nil response instead of throwing an exception. This re-introduces that behavior (with specs), so that only errors that respond to the 'handle' method will be re-raised.